### PR TITLE
Refactor hardcoded paths for cross-platform compatibility

### DIFF
--- a/code/modules/GoproVideo.py
+++ b/code/modules/GoproVideo.py
@@ -21,7 +21,8 @@ class GoproVideo:
         #if arg_options_obj is None:
         #   arg_options_obj = ConfigurationHandler.get_configuration()
         #self.tool_folder = arg_options_obj['GOPRO_VIDEO']['tool_folder']
-        self.tool_folder = os.path.abspath("tools")
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        self.tool_folder = os.path.abspath(os.path.join(current_dir, '..', '..', 'tools'))
 
     def init(self, arg_video_filename):
         if (arg_video_filename != self.current_filename):  # Only initilise if it is a new file

--- a/code/obsolite_junk_box/TrackingTest.py
+++ b/code/obsolite_junk_box/TrackingTest.py
@@ -1,5 +1,6 @@
 import cv2
 import sys
+import os
 sys.path.append('modules')
 import BearTracker
 
@@ -47,7 +48,18 @@ if __name__ == '__main__' :
     #video = cv2.VideoCapture("users/bear/full_clips/20170927_15_43_44_GP020491.mp4")  #Backside slide
     #video = cv2.VideoCapture("users/bear/full_clips/20170927_16_00_50_GP040491.mp4")  # backflip fail
     #video = cv2.VideoCapture("users/bear/full_clips/not_bear_20170927_15_42_40_GP020491.mp4")  # far away jump
-    video = cv2.VideoCapture("C:/git_reps/BearVision/test/users/test_user2/output_video_files/test_user2_20170927_15_58_33.avi")
+    video = cv2.VideoCapture(
+        os.path.join(
+            "C:",
+            "git_reps",
+            "BearVision",
+            "test",
+            "users",
+            "test_user2",
+            "output_video_files",
+            "test_user2_20170927_15_58_33.avi",
+        )
+    )
 
 
     # Exit if video not opened.

--- a/main.py
+++ b/main.py
@@ -13,11 +13,13 @@ logging.basicConfig(filename='debug.log',
                     filemode=write_mode)
 
 if __name__ == "__main__":
-    import sys, tkinter
+    import sys
+    import tkinter
+    import os
 
-    sys.path.append('code\Modules')
-    sys.path.append('code\Application')
-    sys.path.append('code\external_modules')
+    sys.path.append(os.path.join('code', 'Modules'))
+    sys.path.append(os.path.join('code', 'Application'))
+    sys.path.append(os.path.join('code', 'external_modules'))
 
     from Application import Application
     from GUI import BearVisionGUI

--- a/test/BearTracker_test_video.py
+++ b/test/BearTracker_test_video.py
@@ -20,8 +20,8 @@ if __name__ == "__main__":
 
     start_time = time.time()
 
-    modules_abs_path = os.path.abspath("code/modules")
-    dnn_models_abs_path = os.path.abspath("code/dnn_models")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
+    dnn_models_abs_path = os.path.abspath(os.path.join("code", "dnn_models"))
 
     sys.path.append(modules_abs_path)
     sys.path.append(dnn_models_abs_path)
@@ -33,10 +33,10 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
 
     input_video_list = list()
-    input_video_list.append(os.path.abspath("test/test_video/TestMovie1.mp4"))
-    input_video_list.append(os.path.abspath("test/test_video/TestMovie2.mp4"))
-    input_video_list.append(os.path.abspath("test/test_video/TestMovie3.avi"))
-    input_video_list.append(os.path.abspath("test/test_video/TestMovie4.avi"))
+    input_video_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie1.mp4")))
+    input_video_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie2.mp4")))
+    input_video_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie3.avi")))
+    input_video_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie4.avi")))
 
     input_video_list = [input_video_list[3]]
 

--- a/test/CameraViewGenerator_test.py
+++ b/test/CameraViewGenerator_test.py
@@ -19,17 +19,17 @@ if __name__ == "__main__":
     from pprint import pprint
     import cv2
 
-    modules_abs_path = os.path.abspath("code/modules")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
     sys.path.append(modules_abs_path)
     from CameraViewGenerator import CameraViewGenerator
 
     logger = logging.getLogger(__name__)
 
 
-    input_video = os.path.abspath("test/test_video/TestMovie1.mp4")
-    #input_video = os.path.abspath("test/test_video/TestMovie2.mp4")
-    #input_video = os.path.abspath("test/test_video/TestMovie3.avi")
-    #input_video = os.path.abspath("test/test_video/TestMovie4.avi")
+    input_video = os.path.abspath(os.path.join("test", "test_video", "TestMovie1.mp4"))
+    #input_video = os.path.abspath(os.path.join("test", "test_video", "TestMovie2.mp4"))
+    #input_video = os.path.abspath(os.path.join("test", "test_video", "TestMovie3.avi"))
+    #input_video = os.path.abspath(os.path.join("test", "test_video", "TestMovie4.avi"))
 
     pickle_file_name = input_video.split('.')[0] + '_tracking_vars.pkl'
     

--- a/test/ExtractCameraViewClip_test.py
+++ b/test/ExtractCameraViewClip_test.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     import os
     import cv2
 
-    modules_abs_path = os.path.abspath("code/modules")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
     sys.path.append(modules_abs_path)
 
     from ExtractCameraViewClip import ExtractCameraViewClip
@@ -25,10 +25,10 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
 
     pickle_file_name_list = list()
-    pickle_file_name_list.append(os.path.abspath("test/test_video/TestMovie1_113_tracking.pkl"))
-    pickle_file_name_list.append(os.path.abspath("test/test_video/TestMovie2_127_tracking.pkl"))
-    pickle_file_name_list.append(os.path.abspath("test/test_video/TestMovie3_59_tracking.pkl"))
-    pickle_file_name_list.append(os.path.abspath("test/test_video/TestMovie4_1_tracking.pkl"))
+    pickle_file_name_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie1_113_tracking.pkl")))
+    pickle_file_name_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie2_127_tracking.pkl")))
+    pickle_file_name_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie3_59_tracking.pkl")))
+    pickle_file_name_list.append(os.path.abspath(os.path.join("test", "test_video", "TestMovie4_1_tracking.pkl")))
 
     #pickle_file_name_list = [pickle_file_name_list[0]] # single file test
 

--- a/test/ExtractGoproVideo_test.py
+++ b/test/ExtractGoproVideo_test.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     import os
     import cv2
 
-    modules_abs_path = os.path.abspath("code/modules")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
     sys.path.append(modules_abs_path)
 
     from BearTracker import BearTracker

--- a/test/ble_beacon_test.py
+++ b/test/ble_beacon_test.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     import sys
     import os
 
-    modules_abs_path = os.path.abspath("code/modules")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
     sys.path.append(modules_abs_path)
     from ble_beacon_handler import BleBeaconHandler
     logger = logging.getLogger(__name__)

--- a/test/dnn_test_photo.py
+++ b/test/dnn_test_photo.py
@@ -21,8 +21,8 @@ if __name__ == "__main__":
 
     start_time = time.time()
 
-    modules_abs_path = os.path.abspath("code/modules")
-    dnn_models_abs_path = os.path.abspath("code/dnn_models")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
+    dnn_models_abs_path = os.path.abspath(os.path.join("code", "dnn_models"))
 
     sys.path.append(modules_abs_path)
     sys.path.append(dnn_models_abs_path)
@@ -31,11 +31,11 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
 
     input_image_list = list()
-    input_image_list.append(os.path.abspath("test/images/test_image_1.jpg"))
-    input_image_list.append(os.path.abspath("test/images/test_image_2.jpg"))
-    input_image_list.append(os.path.abspath("test/images/test_image_3.jpg"))
-    input_image_list.append(os.path.abspath("test/images/test_image_4.jpg"))
-    input_image_list.append(os.path.abspath("test/images/test_image_5.jpg"))
+    input_image_list.append(os.path.abspath(os.path.join("test", "images", "test_image_1.jpg")))
+    input_image_list.append(os.path.abspath(os.path.join("test", "images", "test_image_2.jpg")))
+    input_image_list.append(os.path.abspath(os.path.join("test", "images", "test_image_3.jpg")))
+    input_image_list.append(os.path.abspath(os.path.join("test", "images", "test_image_4.jpg")))
+    input_image_list.append(os.path.abspath(os.path.join("test", "images", "test_image_5.jpg")))
 
     #input_image_list = [input_image_list[2]]
 

--- a/test/dnn_test_video.py
+++ b/test/dnn_test_video.py
@@ -20,8 +20,8 @@ if __name__ == "__main__":
     import time
 
     start_time = time.time()
-    modules_abs_path = os.path.abspath("code/modules")
-    dnn_models_abs_path = os.path.abspath("code/dnn_models")
+    modules_abs_path = os.path.abspath(os.path.join("code", "modules"))
+    dnn_models_abs_path = os.path.abspath(os.path.join("code", "dnn_models"))
 
     sys.path.append(modules_abs_path)
     sys.path.append(dnn_models_abs_path)
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     logger = logging.getLogger(__name__)
 
-    input_video = os.path.abspath("test/test_video/TestMovie2.mp4")
+    input_video = os.path.abspath(os.path.join("test", "test_video", "TestMovie2.mp4"))
 
     dnn_handler = DnnHandler()
     dnn_handler.init()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -31,9 +31,9 @@ if __name__ == "__main__":
     #tmp_video_folder = os.path.abspath("F:/GoPro/Kabelpark/20180603")
     #tmp_video_folder = os.path.abspath("E:/DCIM/100GOPRO") #  - very slow to read from SD card using converter and build-in reader
     #tmp_user_folder  = os.path.abspath("F:/GoPro/BearVision/users")
-    tmp_video_folder = os.path.abspath("input_video")
-    tmp_user_folder  = os.path.abspath("users")
-    tmp_config_file = os.path.abspath("test_config.ini")
+    tmp_video_folder = os.path.abspath(os.path.join("input_video"))
+    tmp_user_folder  = os.path.abspath(os.path.join("users"))
+    tmp_config_file = os.path.abspath(os.path.join("test_config.ini"))
 
     # list of actions to do in the test
     tmp_action_list = [ActionOptions.GENERATE_MOTION_FILES.value,


### PR DESCRIPTION
## Summary
- ensure runtime paths use `os.path.join`
- update test scripts to construct paths portably
- compute `tools` directory in `GoproVideo`
- fix legacy tracking test path

## Testing
- `python -m py_compile main.py code/modules/GoproVideo.py test/CameraViewGenerator_test.py test/ExtractCameraViewClip_test.py test/BearTracker_test_video.py test/dnn_test_video.py test/dnn_test_photo.py test/ExtractGoproVideo_test.py test/ble_beacon_test.py test/run_test.py code/obsolite_junk_box/TrackingTest.py`

------
https://chatgpt.com/codex/tasks/task_e_687dd46f26c88321901cdccc0d30d735