### PR TITLE
Add CVAT export support

### DIFF
--- a/pretraning/annotation/sample_config.yaml
+++ b/pretraning/annotation/sample_config.yaml
@@ -1,0 +1,14 @@
+videos:
+  - path/to/video1.mp4
+sampling:
+  fps: 2.0
+quality:
+  blur: 120.0
+  luma_min: 50
+  luma_max: 200
+yolo:
+  weights: yolov8n.pt
+  conf_thr: 0.25
+export:
+  output_dir: dataset
+  format: cvat


### PR DESCRIPTION
## Summary
- support CVAT export with new `CvatExporter`
- allow selecting export `format` in config
- add example pipeline configuration
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddecd22dc832190db1c3494b3aa98