### PR TITLE
Add generic test to invoke all module functions

### DIFF
--- a/tests/test_call_modules.py
+++ b/tests/test_call_modules.py
@@ -1,0 +1,50 @@
+import importlib
+import inspect
+import sys
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / 'code' / 'modules'
+
+# Ensure modules directory is on the path for imports
+sys.path.append(str(MODULE_DIR))
+
+def _call_func(func):
+    sig = inspect.signature(func)
+    args = []
+    for p in sig.parameters.values():
+        if p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        if p.default is inspect.Parameter.empty:
+            args.append(None)
+    try:
+        func(*args)
+    except BaseException:
+        # Ignore any errors raised when calling with dummy args
+        pass
+
+def test_call_all_functions_and_methods():
+    for mod_path in MODULE_DIR.glob('*.py'):
+        if mod_path.name == '__init__.py':
+            continue
+        try:
+            module = importlib.import_module(mod_path.stem)
+        except BaseException:
+            # Skip modules that fail to import due to missing dependencies
+            continue
+        for _, func in inspect.getmembers(module, inspect.isfunction):
+            if func.__module__ != module.__name__:
+                continue
+            _call_func(func)
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if cls.__module__ != module.__name__:
+                continue
+            try:
+                init_sig = inspect.signature(cls)
+                init_args = [None for p in init_sig.parameters.values() if p.default is inspect.Parameter.empty]
+                instance = cls(*init_args)
+            except BaseException:
+                continue
+            for _, method in inspect.getmembers(instance, inspect.ismethod):
+                if method.__name__.startswith('_'):
+                    continue
+                _call_func(method)


### PR DESCRIPTION
## Summary
- add a new pytest that imports all modules under `code/modules`
- dynamically call every function and public method once with dummy arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2485f0908321bf50f65f99c8d321