### PR TITLE
Fix test warnings

### DIFF
--- a/code/modules/BearTracker.py
+++ b/code/modules/BearTracker.py
@@ -167,7 +167,9 @@ class BearTracker:
         self.log_state(self.latest_state_estimate)
 
         #Tell if the X position is outside the frame
-        if (int(self.latest_state_estimate[0]) < 0) or (int(self.latest_state_estimate[0]) > arg_frame.shape[1]):
+        if (int(self.latest_state_estimate[0].item()) < 0) or (
+            int(self.latest_state_estimate[0].item()) > arg_frame.shape[1]
+        ):
             return False
         return True
 
@@ -185,8 +187,8 @@ class BearTracker:
 
         search_area_width = int(self.search_area_scale * tmp_x_sigma)
         search_area_height = int(self.search_area_scale * tmp_y_sigma)
-        search_area_x = int(self.latest_state_estimate[0] - 0.5 * search_area_width)
-        search_area_y = int(self.latest_state_estimate[1] - 0.5 * search_area_height)
+        search_area_x = int(self.latest_state_estimate[0].item() - 0.5 * search_area_width)
+        search_area_y = int(self.latest_state_estimate[1].item() - 0.5 * search_area_height)
         search_box = [search_area_x, search_area_y, search_area_width, search_area_height]
 
         # Range check
@@ -203,7 +205,7 @@ class BearTracker:
 
     def visualize_state(self, frame):
         tmp_color = (0, 0, 255) #red
-        tmp_pos = (int(self.latest_state_estimate[0]), int(self.latest_state_estimate[1]))
+        tmp_pos = (int(self.latest_state_estimate[0].item()), int(self.latest_state_estimate[1].item()))
         cv2.circle(frame, tmp_pos, 10, tmp_color, -1)
         cv2.putText(frame, "X-velocity : " + str(self.latest_state_estimate[2]), (120, 80), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (50, 170, 50), 2)
 
@@ -224,7 +226,12 @@ class BearTracker:
 
     def log_state(self, arg_state):
         """Log the state of the tracker"""
-        tmp_state_vec = [int(arg_state[0]), int(arg_state[1]), float(arg_state[2]), float(arg_state[3])]
+        tmp_state_vec = [
+            int(arg_state[0].item()),
+            int(arg_state[1].item()),
+            float(arg_state[2].item()),
+            float(arg_state[3].item()),
+        ]
         self.state_log.append(tmp_state_vec)
         logger.debug("X: %.2f, Y: %.2f, X-velocity: %.2f, Y-velocity: %.2f", tmp_state_vec[0], tmp_state_vec[1], tmp_state_vec[2], tmp_state_vec[3])
 

--- a/code/modules/TrackerClipExtractor.py
+++ b/code/modules/TrackerClipExtractor.py
@@ -62,7 +62,9 @@ class TrackerClipExtractor:
             if read_return_value == 20:  # GoPro video error
                 continue
 
-            if iterator is 0:
+            # Using "is" with a literal triggers a SyntaxWarning. We only need
+            # to compare the value of ``iterator``.
+            if iterator == 0:
                 # Init tracker
                 tmp_tracker.init(frame, arg_clip_spec.init_bbox)
                 tmp_tracker_return_code, tmp_bbox = tmp_tracker.update(frame)

--- a/pretraning/annotation/annotation_pipeline.py
+++ b/pretraning/annotation/annotation_pipeline.py
@@ -105,11 +105,15 @@ class PreLabelYOLO:
         results = self.model(frame)[0]
         boxes = []
         for b in results.boxes:
-            conf = float(b.conf[0])
+            # `b.conf` and `b.cls` are numpy arrays with a single element in YOLO
+            # results. Converting them directly using ``float()`` or ``int()``
+            # raises a ``DeprecationWarning`` on newer NumPy versions. ``item()``
+            # safely extracts the scalar value.
+            conf = float(b.conf[0].item())
             if conf < self.conf_thr:
                 continue
             x1, y1, x2, y2 = b.xyxy[0].tolist()
-            cls_id = int(b.cls[0])
+            cls_id = int(b.cls[0].item())
             boxes.append({
                 "bbox": [x1, y1, x2, y2],
                 "cls": cls_id,

--- a/tests/test_call_modules.py
+++ b/tests/test_call_modules.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import sys
+import asyncio
 from pathlib import Path
 
 MODULE_DIR = Path(__file__).resolve().parents[1] / 'code' / 'modules'
@@ -17,6 +18,9 @@ def _call_func(func):
         if p.default is inspect.Parameter.empty:
             args.append(None)
     try:
+        if inspect.iscoroutinefunction(func):
+            # Skip async functions to avoid hanging during tests
+            return
         func(*args)
     except BaseException:
         # Ignore any errors raised when calling with dummy args


### PR DESCRIPTION
## Summary
- fix `PreLabelYOLO.detect` scalar conversion deprecation warnings
- avoid running async functions in `test_call_modules`
- fix `TrackerClipExtractor` SyntaxWarning
- use `.item()` for numpy scalars in `BearTracker`
- all tests pass without warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b4290978832189e14e18908a84be