### PR TITLE
Replace typer with argparse

### DIFF
--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -10,7 +10,7 @@ import numpy as np
 import types
 sys.modules['ultralytics'] = types.SimpleNamespace(YOLO=lambda *a, **k: None)
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / 'pretraning' / 'annotation'
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'pretraining' / 'annotation'
 sys.path.append(str(MODULE_PATH))
 import annotation_pipeline as ap
 

--- a/tests/test_annotation_pipeline_full.py
+++ b/tests/test_annotation_pipeline_full.py
@@ -5,13 +5,12 @@ from unittest import mock
 
 import numpy as np
 import yaml
-from typer.testing import CliRunner
 import shutil
 
 # Ensure the annotation module can be imported without ultralytics installed
 sys.modules['ultralytics'] = types.SimpleNamespace(YOLO=lambda *a, **k: None)
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / 'pretraning' / 'annotation'
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'pretraining' / 'annotation'
 sys.path.append(str(MODULE_PATH))
 import annotation_pipeline as ap
 
@@ -56,9 +55,7 @@ def test_pipeline_full(tmp_path):
 
     with mock.patch.object(ap, 'YOLO', DummyModel), \
          mock.patch.object(ap, 'load_config', side_effect=load_cfg):
-        runner = CliRunner()
-        result = runner.invoke(ap.app, ['run', str(cfg_path)])
-    assert result.exit_code == 0
+        ap.main(['run', str(cfg_path)])
 
     imgs = list((dataset_dir / 'images').glob('*.jpg'))
     lbls = list((dataset_dir / 'labels').glob('*.txt'))


### PR DESCRIPTION
## Summary
- drop `typer` usage in annotation pipeline
- expose an `argparse` CLI
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f25cc76083218089cb01cb342ee6