### PR TITLE
Update annotation pipeline to use DnnHandler

### DIFF
--- a/pretraining/annotation/sample_config.yaml
+++ b/pretraining/annotation/sample_config.yaml
@@ -7,7 +7,7 @@ quality:
   luma_min: 50
   luma_max: 200
 yolo:
-  weights: yolov8n.pt
+  weights: yolov8s.onnx
   conf_thr: 0.25
 export:
   output_dir: dataset

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -80,6 +80,23 @@ def test_prelabel_yolo_detection():
     ]
 
 
+def test_prelabel_with_dnn_handler():
+    with mock.patch.object(ap, 'DnnHandler') as dh_mock:
+        instance = dh_mock.return_value
+        instance.init.return_value = None
+        instance.find_person.return_value = ([[1, 2, 3, 4]], [0.9])
+        yolo = ap.PreLabelYOLO(ap.YoloConfig(weights='yolov8s.onnx', conf_thr=0.5))
+        out = yolo.detect(np.zeros((10, 10, 3), dtype=np.uint8))
+    assert out == [
+        {
+            'bbox': [1, 2, 4, 6],
+            'cls': 0,
+            'label': 'wakeboarder',
+            'conf': 0.9,
+        }
+    ]
+
+
 def test_dataset_exporter(tmp_path):
     exporter = ap.DatasetExporter(ap.ExportConfig(output_dir=str(tmp_path)))
     item = {'frame': np.zeros((4, 4, 3), dtype=np.uint8), 'frame_idx': 1, 'video': str(tmp_path / 'vid.mp4')}


### PR DESCRIPTION
## Summary
- integrate `DnnHandler` into the annotation pipeline for ONNX models
- default sample config uses `yolov8s.onnx`
- extend annotation pipeline unit tests
- update full pipeline test to mock `DnnHandler`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882781b13988321a566ac27e97a75dd