### PR TITLE
Add env var check without monkeypatch

### DIFF
--- a/tests/test_google_credentials_json.py
+++ b/tests/test_google_credentials_json.py
@@ -1,0 +1,7 @@
+import os
+
+
+def test_google_credentials_json_defined_and_not_unset():
+    value = os.getenv('GOOGLE_CREDENTIALS_JSON')
+    assert value is not None and value != '', 'GOOGLE_CREDENTIALS_JSON should be set'
+    assert value != 'UNSET', 'GOOGLE_CREDENTIALS_JSON should not be UNSET'


### PR DESCRIPTION
## Summary
- adjust test to simply read `GOOGLE_CREDENTIALS_JSON` from environment

## Testing
- `pytest -q` *(fails: GOOGLE_CREDENTIALS_JSON not set)*

------
https://chatgpt.com/codex/tasks/task_e_68827fd0fbb083218cdcbc47bff6160e