### PR TITLE
Fix Android workflow path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,6 +21,7 @@ jobs:
         cache: gradle
 
     - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      run: chmod +x android_app/gradlew
     - name: Build with Gradle
       run: ./gradlew build
+      working-directory: android_app


### PR DESCRIPTION
## Summary
- build Android app under `android_app` instead of repository root

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6882911f94d88321a4422065747933a1