### PR TITLE
Fix env var name

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -82,5 +82,5 @@ TCX_dummy_hdop = 0.1
 TCX_dummy_satellites = 99
 [GOOGLE_DRIVE]
 account = BearVisionApp@gmail.com
-secret_key_name = GOOGLE_CREDENTIAL_JSON
+secret_key_name = GOOGLE_CREDENTIALS_JSON
 root_folder = bearvison_files

--- a/tests/test_google_drive.py
+++ b/tests/test_google_drive.py
@@ -18,8 +18,8 @@ except Exception:
 
 @pytest.mark.skipif(GoogleDriveHandler is None, reason="Google Drive dependencies missing")
 def test_google_drive_upload_download(tmp_path):
-    if not os.getenv('GOOGLE_CREDENTIAL_JSON'):
-        pytest.skip('GOOGLE_CREDENTIAL_JSON not set')
+    if not os.getenv('GOOGLE_CREDENTIALS_JSON'):
+        pytest.skip('GOOGLE_CREDENTIALS_JSON not set')
 
     cfg_path = ROOT / 'config.ini'
     ConfigurationHandler.read_config_file(str(cfg_path))


### PR DESCRIPTION
## Summary
- use `GOOGLE_CREDENTIALS_JSON` everywhere

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6882ac056af083219c7855686552a6c5