### PR TITLE
Ignore obsolete folder for linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-exclude = obsolite_junk_box

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ android_app/.gradle/
 android_app/build/
 android_app/app/build/
 last_used_config.ini
+

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,1 +1,3 @@
+[MASTER]
 extension-pkg-whitelist=cv2
+ignore=obsolite_junk_box


### PR DESCRIPTION
## Summary
- make flake8 ignore `obsolite_junk_box`
- tell pylint to ignore the folder
- keep repo tracking for obsolete files by reverting `.gitignore`

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6882aead99888321ba5997dc1431647a