### PR TITLE
Fix regex escape warnings

### DIFF
--- a/code/modules/GoproVideo.py
+++ b/code/modules/GoproVideo.py
@@ -83,7 +83,7 @@ class GoproVideo:
             textfile = open(temp_json_file_name, 'r')
             filetext = textfile.read()
             textfile.close()
-            utc_time_match_list = re.findall("(?<=\"utc\":)\d+", filetext)
+            utc_time_match_list = re.findall(r"(?<=\"utc\":)\d+", filetext)
             if utc_time_match_list:
                 utc_time = int(utc_time_match_list[0])
             else:
@@ -116,7 +116,7 @@ class GoproVideo:
             print(err)
         # return -1
         out_string = out.decode('UTF-8')
-        create_time_str = re.findall("(?<=creation_time=)[\S\ \-\:]+", out_string)[0]
+        create_time_str = re.findall(r"(?<=creation_time=)[\S\ \-\:]+", out_string)[0]
         # print(create_time_str)
         self.creation_time = dt.datetime.strptime(create_time_str, "%Y-%m-%d %H:%M:%S")
 

--- a/code/modules/MotionFilesHandler.py
+++ b/code/modules/MotionFilesHandler.py
@@ -38,7 +38,7 @@ class MotionFilesHandler:
     def get_motion_file_list(arg_input_video_folder):
         tmp_options = ConfigurationHandler.get_configuration()
         tmp_motion_file_ending = tmp_options['MOTION_DETECTION']['motion_file_ending']
-        tmp_motion_file_ending_regex = re.compile(".+" + tmp_motion_file_ending + "\.csv$")
+        tmp_motion_file_ending_regex = re.compile(r".+" + tmp_motion_file_ending + r"\.csv$")
         motion_file_list = []
         for dir_file in os.scandir(arg_input_video_folder):
             # logger.debug("Checking if the following file is a motion start file: " + dir_file.name)

--- a/code/obsolite_junk_box/GoproVideo_from_cutextractor.py
+++ b/code/obsolite_junk_box/GoproVideo_from_cutextractor.py
@@ -33,7 +33,7 @@ class GoproVideo:
 			print("========= error ========")
 			print(err)
 		out_string = out.decode('UTF-8');
-		create_time_str = re.findall("(?<=creation_time=)[\S\ \-\:]+", out_string)[0]
+                create_time_str = re.findall(r"(?<=creation_time=)[\S\ \-\:]+", out_string)[0]
 		#print(create_time_str)
 		self.creation_time = dt.datetime.strptime(create_time_str, "%Y-%m-%d %H:%M:%S")
 		

--- a/code/obsolite_junk_box/Sensordata_to_GPS.py
+++ b/code/obsolite_junk_box/Sensordata_to_GPS.py
@@ -22,7 +22,7 @@ textfile.close()
 if (verbose):
 	print("filetext: " + filetext)
 
-start_time_ms  = int(re.findall("(?<=\"start\":)\d+", filetext)[0])
+start_time_ms  = int(re.findall(r"(?<=\"start\":)\d+", filetext)[0])
 
 if (verbose):
 	print("start_time_ms: " + str(start_time_ms))

--- a/code/obsolite_junk_box/clip_identify.py
+++ b/code/obsolite_junk_box/clip_identify.py
@@ -37,7 +37,7 @@ for inbox_entry in os.scandir(inbox_video_directory):
     if inbox_entry.name.endswith('.MP4') and inbox_entry.is_file():
         # print("Checking for GPS matches on file: " + inbox_entry.name)
         stopwatch_start = time.time()
-        inbox_entry_start_time = datetime.datetime.strptime(re.findall("\d+\_\d+\_\d+\_\d+", inbox_entry.name)[0], "%Y%m%d_%H_%M_%S")
+        inbox_entry_start_time = datetime.datetime.strptime(re.findall(r"\d+\_\d+\_\d+\_\d+", inbox_entry.name)[0], "%Y%m%d_%H_%M_%S")
 
         #print("Video time: " + inbox_entry_start_time.strftime("%Y%m%d_%H_%M_%S"))
         if test_user.is_close(inbox_entry_start_time + clock_correction, jump_approach_location):


### PR DESCRIPTION
## Summary
- convert regex patterns to raw strings

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6882b3c518148321af125f2e4e4c4ac6