### PR TITLE
Fix config handler revert and ignore vendor

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-extend-exclude = obsolite_junk_box
+extend-exclude = obsolite_junk_box, external_modules


### PR DESCRIPTION
## Summary
- restore `global` declarations in ConfigurationHandler
- keep external_modules ignored by flake8

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: F824 warnings)*
- `pytest -q` *(fails: ImportError libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883b447dfc48321bae04d3e526fb6a3