### PR TITLE
Add GoPro controller module without Google Drive stubs

### DIFF
--- a/code/modules/GoProController.py
+++ b/code/modules/GoProController.py
@@ -1,0 +1,62 @@
+import asyncio
+from pathlib import Path
+import logging
+from open_gopro import WirelessGoPro, models
+from open_gopro.models.constants import settings
+from open_gopro.models.streaming import StreamType, PreviewStreamOptions
+
+logger = logging.getLogger(__name__)
+
+
+class GoProController:
+    """Simplified wrapper around the OpenGoPro API."""
+
+    def __init__(self, target: str | None = None) -> None:
+        self._gopro = WirelessGoPro(target=target)
+
+    def connect(self) -> None:
+        """Open connection to the GoPro."""
+        asyncio.run(self._gopro.open())
+
+    def disconnect(self) -> None:
+        """Close connection to the GoPro."""
+        asyncio.run(self._gopro.close())
+
+    def list_videos(self) -> list[str]:
+        """Return list of video filenames stored on the camera."""
+        resp = asyncio.run(self._gopro.http_command.get_media_list())
+        return [f.filename for f in resp.data.files]
+
+    def download_file(self, camera_file: str, local_path: str) -> Path:
+        """Download a specific file from the camera."""
+        resp = asyncio.run(
+            self._gopro.http_command.download_file(
+                camera_file=camera_file, local_file=Path(local_path)
+            )
+        )
+        return resp.data
+
+    def configure(self) -> None:
+        """Configure the GoPro for BearVision usage."""
+        asyncio.run(self._configure())
+
+    async def _configure(self) -> None:
+        await self._gopro.http_command.load_preset_group(
+            group=models.proto.EnumPresetGroup.PRESET_GROUP_ID_VIDEO
+        )
+        await self._gopro.http_settings.video_resolution.set(
+            settings.VideoResolution.NUM_4K
+        )
+        await self._gopro.http_settings.frames_per_second.set(
+            settings.FramesPerSecond.NUM_60_0
+        )
+        await self._gopro.http_settings.hindsight.set(
+            settings.Hindsight.NUM_15_SECONDS
+        )
+
+    def start_preview(self, port: int = 8554) -> str:
+        """Start preview stream and return its URL."""
+        options = PreviewStreamOptions(port=port)
+        asyncio.run(self._gopro.streaming.start_stream(StreamType.PREVIEW, options))
+        assert self._gopro.streaming.url is not None
+        return self._gopro.streaming.url

--- a/code/modules/__init__.py
+++ b/code/modules/__init__.py
@@ -1,0 +1,6 @@
+"""Helper package for BearVision modules."""
+import importlib
+import sys
+
+_cfg = importlib.import_module('ConfigurationHandler')
+sys.modules.setdefault(__name__ + '.ConfigurationHandler', _cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ lxml
 opencv-python-headless
 google-auth
 google-api-python-client
+open_gopro

--- a/tests/test_gopro_controller.py
+++ b/tests/test_gopro_controller.py
@@ -1,0 +1,99 @@
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / 'code' / 'modules'
+sys.path.append(str(MODULE_DIR))
+from GoProController import GoProController
+
+
+class DummyResp:
+    def __init__(self, data=None, ok=True, status=200):
+        self.data = data
+        self.ok = ok
+        self.status = status
+
+
+class FakeHttpCommand:
+    def __init__(self):
+        self.group = None
+        self.downloaded = None
+
+    async def get_media_list(self):
+        item = types.SimpleNamespace(filename='DCIM/100GOPRO/GOPR0001.MP4')
+        data = types.SimpleNamespace(files=[item])
+        return DummyResp(data)
+
+    async def download_file(self, *, camera_file, local_file=None):
+        Path(local_file).write_text('data')
+        self.downloaded = (camera_file, str(local_file))
+        return DummyResp(Path(local_file))
+
+    async def load_preset_group(self, *, group):
+        self.group = group
+        return DummyResp()
+
+    async def set_preview_stream(self, *, mode, port=None):
+        self.preview = (mode, port)
+        return DummyResp()
+
+
+class FakeSetting:
+    def __init__(self):
+        self.value = None
+
+    async def set(self, value):
+        self.value = value
+        return DummyResp()
+
+
+class FakeHttpSettings:
+    def __init__(self):
+        self.video_resolution = FakeSetting()
+        self.frames_per_second = FakeSetting()
+        self.hindsight = FakeSetting()
+
+
+class FakeStreaming:
+    def __init__(self):
+        self.url = None
+
+    async def start_stream(self, stream_type, options):
+        self.url = f"udp://127.0.0.1:{options.port}"
+        return DummyResp()
+
+
+class FakeGoPro:
+    def __init__(self, *a, **k):
+        self.http_command = FakeHttpCommand()
+        self.http_settings = FakeHttpSettings()
+        self.streaming = FakeStreaming()
+
+    async def open(self, *a, **k):
+        return None
+
+    async def close(self, *a, **k):
+        return None
+
+
+def test_list_and_download(tmp_path):
+    with mock.patch('GoProController.WirelessGoPro', FakeGoPro):
+        ctrl = GoProController()
+        files = ctrl.list_videos()
+        assert files == ['DCIM/100GOPRO/GOPR0001.MP4']
+
+        out = tmp_path / 'f.mp4'
+        ctrl.download_file('DCIM/100GOPRO/GOPR0001.MP4', str(out))
+        assert out.exists()
+
+
+def test_configure_and_preview():
+    with mock.patch('GoProController.WirelessGoPro', FakeGoPro):
+        ctrl = GoProController()
+        ctrl.configure()
+        gopro = ctrl._gopro
+        assert gopro.http_command.group is not None
+        assert gopro.http_settings.hindsight.value is not None
+        url = ctrl.start_preview(9000)
+        assert url == 'udp://127.0.0.1:9000'


### PR DESCRIPTION
## Summary
- implement `GoProController` to control GoPro cameras via OpenGoPro
- provide unit tests with a fake GoPro
- revert earlier stub changes in `GoogleDriveHandler`

## Testing
- `pytest tests/test_gopro_controller.py -q`
- `pytest -q` *(fails: GOOGLE_CREDENTIALS_JSON unset and Google Drive upload test expects real credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68838af2f2f883218f9357fa1802a59a