### PR TITLE
Upgrade android to Java 21

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -15,11 +15,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
 }
 


### PR DESCRIPTION
## Summary
- set Java compilation target to 21 in the Android module

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68847e7593f48321866363c133579a59