### PR TITLE
Update Android build JDK version

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 17
+    - name: set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
 

--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -15,11 +15,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '21'
     }
 }
 


### PR DESCRIPTION
## Summary
- use JDK 21 for the Android app
- update the CI workflow to run on JDK 21

## Testing
- `pytest -q` *(fails: GOOGLE_CREDENTIALS_JSON missing)*

------
https://chatgpt.com/codex/tasks/task_e_688669a2c0848321803d59859cd62ddb