### PR TITLE
Fix google API build cache issue

### DIFF
--- a/code/modules/GoogleDriveHandler.py
+++ b/code/modules/GoogleDriveHandler.py
@@ -128,7 +128,7 @@ class GoogleDriveHandler:
             self.service = FakeDriveService()
             return
         creds = Credentials.from_service_account_info(info, scopes=['https://www.googleapis.com/auth/drive'])
-        self.service = build('drive', 'v3', credentials=creds)
+        self.service = build('drive', 'v3', credentials=creds, cache_discovery=False)
 
     def _ensure_root(self):
         if isinstance(self.config, ConfigParser):


### PR DESCRIPTION
## Summary
- disable google discovery cache when creating Drive service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869622edc883219f6d3aae611541b7