### PR TITLE
Fix google drive tests by stubbing missing modules

### DIFF
--- a/tests/test_google_drive_authenticate.py
+++ b/tests/test_google_drive_authenticate.py
@@ -15,6 +15,61 @@ class DummyCreds:
     pass
 
 
+# ---------------------------------------------------------------------------
+# Helpers to ensure the tests run even when the real Google packages are
+# missing or incomplete. Some versions of ``google-api-python-client`` try to
+# import an optional ``discovery_cache`` module on import.  If that import fails
+# the whole ``googleapiclient.discovery`` module cannot be loaded.  To make the
+# tests robust we provide lightweight stub modules whenever the real ones are
+# unavailable.
+# ---------------------------------------------------------------------------
+sys.modules.setdefault('google', types.ModuleType('google'))
+
+try:
+    import googleapiclient.discovery  # noqa: F401
+    import googleapiclient.http  # noqa: F401
+    import google.oauth2.service_account  # noqa: F401
+except Exception:  # pragma: no cover - only executed when deps are missing
+    oauth2_mod = types.ModuleType('google.oauth2')
+    service_account_mod = types.ModuleType('google.oauth2.service_account')
+
+    service_account_mod.Credentials = types.SimpleNamespace(
+        from_service_account_info=lambda info, scopes=None: DummyCreds()
+    )
+    oauth2_mod.service_account = service_account_mod
+
+    apiclient_mod = types.ModuleType('googleapiclient')
+    disc_mod = types.ModuleType('googleapiclient.discovery')
+    http_mod = types.ModuleType('googleapiclient.http')
+
+    disc_mod.build = lambda *a, **k: None
+
+    class DummyMediaFileUpload:
+        def __init__(self, filename, resumable=False):
+            self.filename = filename
+
+    class DummyMediaIoBaseDownload:
+        def __init__(self, fh, request):
+            self.fh = fh
+            self.request = request
+            self.done = False
+
+        def next_chunk(self):
+            if not self.done:
+                self.fh.write(self.request.content)
+                self.done = True
+            return None, self.done
+
+    http_mod.MediaFileUpload = DummyMediaFileUpload
+    http_mod.MediaIoBaseDownload = DummyMediaIoBaseDownload
+
+    sys.modules.setdefault('google.oauth2', oauth2_mod)
+    sys.modules.setdefault('google.oauth2.service_account', service_account_mod)
+    sys.modules.setdefault('googleapiclient', apiclient_mod)
+    sys.modules.setdefault('googleapiclient.discovery', disc_mod)
+    sys.modules.setdefault('googleapiclient.http', http_mod)
+
+
 def setup_google_modules(monkeypatch, captured_info):
     import google.oauth2.service_account as sa_mod
     import googleapiclient.discovery as disc_mod


### PR DESCRIPTION
## Summary
- make `test_google_drive_authenticate` robust to missing `googleapiclient.discovery_cache`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a82d2114832183e5fcf70d5c0bbe