### PR TITLE
Update edge_main to configure GoPro on startup

### DIFF
--- a/code/Application/edge_main.py
+++ b/code/Application/edge_main.py
@@ -1,6 +1,14 @@
 import logging
 import threading
 import time
+from pathlib import Path
+import sys
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / "modules"
+sys.path.append(str(MODULE_DIR))
+
+from ConfigurationHandler import ConfigurationHandler
+from GoProController import GoProController
 
 
 logger = logging.getLogger(__name__)
@@ -19,8 +27,19 @@ def _moment_detector():
 
 
 def main() -> list[threading.Thread]:
-    """Start preview and moment detection threads."""
+    """Load configuration, setup GoPro and start edge threads."""
     logging.basicConfig(level=logging.INFO)
+
+    cfg_path = Path(__file__).resolve().parents[2] / "config.ini"
+    ConfigurationHandler.read_config_file(str(cfg_path))
+    logger.info("Loaded configuration from %s", cfg_path)
+
+    gopro = GoProController()
+    gopro.connect()
+    gopro.configure()
+    gopro.start_preview()
+    logger.info("GoPro setup complete")
+
     preview_thread = threading.Thread(target=_preview_algorithm, name="preview", daemon=True)
     moment_thread = threading.Thread(target=_moment_detector, name="detector", daemon=True)
     preview_thread.start()

--- a/tests/test_edge_main.py
+++ b/tests/test_edge_main.py
@@ -1,6 +1,7 @@
 import sys
 import threading
 from pathlib import Path
+from unittest import mock
 
 APP_DIR = Path(__file__).resolve().parents[1] / 'code' / 'Application'
 sys.path.append(str(APP_DIR))
@@ -8,11 +9,21 @@ sys.path.append(str(APP_DIR))
 import edge_main
 
 
-def test_main_starts_threads():
-    before = set(threading.enumerate())
-    threads = edge_main.main()
-    after = set(threading.enumerate())
-    # Ensure new threads started
-    assert len(after - before) >= 2
-    for t in threads:
-        assert t.is_alive()
+def test_main_starts_threads_and_sets_up():
+    with mock.patch.object(edge_main.ConfigurationHandler, 'read_config_file') as read_cfg, \
+         mock.patch.object(edge_main, 'GoProController') as GC:
+        ctrl = GC.return_value
+
+        before = set(threading.enumerate())
+        threads = edge_main.main()
+        after = set(threading.enumerate())
+
+        cfg_path = Path(__file__).resolve().parents[1] / 'config.ini'
+        read_cfg.assert_called_once_with(str(cfg_path))
+        ctrl.connect.assert_called_once()
+        ctrl.configure.assert_called_once()
+        ctrl.start_preview.assert_called_once()
+
+        assert len(after - before) >= 2
+        for t in threads:
+            assert t.is_alive()


### PR DESCRIPTION
## Summary
- load configuration at startup
- connect/configure GoPro and start preview before launching threads
- update unit test for new setup behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688927b70d848321b42e0c0d640a0f35