### PR TITLE
Add asyncio event handling for preview detection

### DIFF
--- a/code/Application/edge_main.py
+++ b/code/Application/edge_main.py
@@ -1,27 +1,68 @@
 import logging
 import threading
+import asyncio
 import time
+try:
+    from modules.GoProController import GoProController
+except ImportError:  # Fall back when modules path isn't in sys.path
+    from GoProController import GoProController
 
 
 logger = logging.getLogger(__name__)
 
 
-def _preview_algorithm():
-    """Placeholder preview algorithm running in a thread."""
+async def _preview_algorithm(event: asyncio.Event) -> None:
+    """Simulate preview processing and emit a motion event."""
+    counter = 0
     while True:
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
+        # In real code this would analyse the preview stream and
+        # call ``event.set()`` whenever motion is detected.
+        counter += 1
+        if counter % 50 == 0:
+            logger.debug("Motion detected in preview")
+            event.set()
 
 
-def _moment_detector():
+async def _hindsight_trigger(event: asyncio.Event, gopro: GoProController | None) -> None:
+    """Wait for the motion event and optionally trigger a HindSight clip."""
+    while True:
+        await event.wait()
+        event.clear()
+        logger.info("HindSight clip triggered")
+        if gopro:
+            gopro.start_hindsight_clip()
+
+
+def _run_async(event: asyncio.Event, gopro: GoProController | None) -> None:
+    """Run preview and HindSight tasks in an event loop."""
+    async def _runner() -> None:
+        if gopro:
+            gopro.start_preview()
+        await asyncio.gather(
+            _preview_algorithm(event),
+            _hindsight_trigger(event, gopro),
+        )
+
+    asyncio.run(_runner())
+
+
+def _moment_detector() -> None:
     """Placeholder moment detection running in a thread."""
     while True:
         time.sleep(0.1)
 
 
-def main() -> list[threading.Thread]:
+def main(gopro: GoProController | None = None) -> list[threading.Thread]:
     """Start preview and moment detection threads."""
     logging.basicConfig(level=logging.INFO)
-    preview_thread = threading.Thread(target=_preview_algorithm, name="preview", daemon=True)
+    motion_event = asyncio.Event()
+    preview_thread = threading.Thread(
+        target=_run_async,
+        args=(motion_event, gopro),
+        name="preview",
+        daemon=True,
+    )
     moment_thread = threading.Thread(target=_moment_detector, name="detector", daemon=True)
     preview_thread.start()
     moment_thread.start()

--- a/code/modules/GoProController.py
+++ b/code/modules/GoProController.py
@@ -4,6 +4,7 @@ import logging
 from open_gopro import WirelessGoPro, models
 from open_gopro.models.constants import settings
 from open_gopro.models.streaming import StreamType, PreviewStreamOptions
+from open_gopro.models.constants import constants
 
 logger = logging.getLogger(__name__)
 
@@ -60,3 +61,12 @@ class GoProController:
         asyncio.run(self._gopro.streaming.start_stream(StreamType.PREVIEW, options))
         assert self._gopro.streaming.url is not None
         return self._gopro.streaming.url
+
+    def start_hindsight_clip(self, duration: float = 1.0) -> None:
+        """Trigger a HindSight capture on the camera."""
+        asyncio.run(self._start_hindsight_clip(duration))
+
+    async def _start_hindsight_clip(self, duration: float) -> None:
+        await self._gopro.http_command.set_shutter(shutter=constants.Toggle.ENABLE)
+        await asyncio.sleep(duration)
+        await self._gopro.http_command.set_shutter(shutter=constants.Toggle.DISABLE)

--- a/tests/stubs/gopro.py
+++ b/tests/stubs/gopro.py
@@ -9,6 +9,7 @@ class FakeHttpCommand:
     def __init__(self):
         self.group = None
         self.downloaded = None
+        self.shutter = []
 
     async def get_media_list(self):
         import types
@@ -28,6 +29,10 @@ class FakeHttpCommand:
 
     async def set_preview_stream(self, *, mode, port=None):
         self.preview = (mode, port)
+        return DummyResp()
+
+    async def set_shutter(self, *, shutter):
+        self.shutter.append(shutter)
         return DummyResp()
 
 

--- a/tests/test_gopro_controller.py
+++ b/tests/test_gopro_controller.py
@@ -7,6 +7,7 @@ sys.path.append(str(MODULE_DIR))
 from GoProController import GoProController
 
 from tests.stubs.gopro import FakeGoPro
+from open_gopro.models.constants import constants
 
 
 def test_list_and_download(tmp_path):
@@ -29,3 +30,12 @@ def test_configure_and_preview():
         assert gopro.http_settings.hindsight.value is not None
         url = ctrl.start_preview(9000)
         assert url == 'udp://127.0.0.1:9000'
+
+
+def test_start_hindsight_clip():
+    with mock.patch('GoProController.WirelessGoPro', FakeGoPro):
+        ctrl = GoProController()
+        ctrl.start_hindsight_clip(0)
+        gopro = ctrl._gopro
+        assert gopro.http_command.shutter == [constants.Toggle.ENABLE, constants.Toggle.DISABLE]
+


### PR DESCRIPTION
## Summary
- convert preview detection demo to asyncio
- fire an asyncio event to signal detection
- start preview and handler on the same event loop
- simulate detection every few iterations
- add GoProController.hindsight recording
- unit test new hindSight flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889281b46a8832182112cd1fea1b2ad