### PR TITLE
Prepare low-res input and enable GoPro streaming mock

### DIFF
--- a/docs/gopro_mock.md
+++ b/docs/gopro_mock.md
@@ -1,0 +1,25 @@
+# GoPro Mock Usage
+
+The integration tests rely on a lightweight GoPro mock to emulate
+camera behaviour without hardware.
+
+## Video files
+
+- `test/input_video/TestMovie1.mp4` – high resolution sample used for
+the streaming endpoint.
+- `tests/data/preview_low.mp4` – low resolution version generated from
+  the file above for preview algorithms.
+
+To regenerate the preview file run:
+
+```bash
+python tools/make_preview_video.py test/input_video/TestMovie1.mp4 tests/data/preview_low.mp4
+```
+
+## Streaming interface
+
+`tests.stubs.gopro.FakeGoPro` exposes a `streaming` component that
+serves the high‑res video over HTTP when `start_stream` is invoked.
+The returned URL points to a local HTTP server streaming the video
+content in real time. Use `stop()` on the streaming object to shut the
+server down when finished.

--- a/tests/data/preview_low.mp4
+++ b/tests/data/preview_low.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83faf0dc9735764a146272e68c70464e82460d5f3994eff9aa7d14611b8c6e28
+size 644938

--- a/tests/test_gopro_controller.py
+++ b/tests/test_gopro_controller.py
@@ -28,4 +28,4 @@ def test_configure_and_preview():
         assert gopro.http_command.group is not None
         assert gopro.http_settings.hindsight.value is not None
         url = ctrl.start_preview(9000)
-        assert url == 'udp://127.0.0.1:9000'
+        assert url == 'http://127.0.0.1:9000/stream'

--- a/tests/test_gopro_stream.py
+++ b/tests/test_gopro_stream.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from unittest import mock
+import urllib.request
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / 'code' / 'modules'
+sys.path.append(str(MODULE_DIR))
+from GoProController import GoProController
+
+from tests.stubs.gopro import FakeGoPro
+
+
+def test_stream_serves_video():
+    with mock.patch('GoProController.WirelessGoPro', FakeGoPro):
+        ctrl = GoProController()
+        url = ctrl.start_preview(9100)
+        import time
+        time.sleep(0.1)
+        with urllib.request.urlopen(url) as resp:
+            data = resp.read(1024)
+        assert data, 'no data returned from stream'
+        ctrl._gopro.streaming.stop()

--- a/tools/make_preview_video.py
+++ b/tools/make_preview_video.py
@@ -1,0 +1,35 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a low-res preview video")
+    parser.add_argument("input", help="High resolution input video")
+    parser.add_argument("output", help="Output preview video path")
+    parser.add_argument("--width", type=int, default=320, help="Output width")
+    parser.add_argument("--crf", type=int, default=28, help="ffmpeg CRF value")
+    args = parser.parse_args()
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(Path(args.input)),
+        "-vf",
+        f"scale={args.width}:-2",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "fast",
+        "-crf",
+        str(args.crf),
+        "-c:a",
+        "copy",
+        str(Path(args.output)),
+    ]
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add low‑resolution preview video
- extend GoPro stub to stream video over HTTP
- provide script to convert high‑res video
- add tests for new streaming behaviour
- document mock and file locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688af950829c83218b6f921806ff3941