### PR TITLE
Fix tkinter crash in tests

### DIFF
--- a/code/modules/MotionROISelector.py
+++ b/code/modules/MotionROISelector.py
@@ -17,7 +17,12 @@ class MotionROISelector:
     def SelectROI(self, arg_input_video_folder):
         logger.debug("SelectROI() called")
         tmp_options = ConfigurationHandler.get_configuration()
-        tmpVideoFileName = filedialog.askopenfilename(initialdir = arg_input_video_folder, title = "Select video file")
+
+        if arg_input_video_folder is None:
+            logger.debug("No input folder provided, skipping ROI selection")
+            return None
+
+        tmpVideoFileName = filedialog.askopenfilename(initialdir=arg_input_video_folder, title="Select video file")
 
         MyGoproVideo = GoproVideo.GoproVideo(tmp_options)
         MyGoproVideo.init(tmpVideoFileName)


### PR DESCRIPTION
## Summary
- avoid GUI call when MotionROISelector.SelectROI gets `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d24b567348321a63f1f6b287e8d32