### PR TITLE
Fix preview streaming server reuse

### DIFF
--- a/tests/stubs/gopro.py
+++ b/tests/stubs/gopro.py
@@ -86,7 +86,10 @@ class FakeStreaming:
                         self.wfile.write(chunk)
                         time.sleep(0.01)
 
-        self._server = socketserver.TCPServer(("127.0.0.1", port), Handler)
+        class ReusableTCPServer(socketserver.TCPServer):
+            allow_reuse_address = True
+
+        self._server = ReusableTCPServer(("127.0.0.1", port), Handler)
         self._server.serve_forever()
 
     async def start_stream(self, stream_type, options):
@@ -101,6 +104,7 @@ class FakeStreaming:
     def stop(self) -> None:
         if self._server is not None:
             self._server.shutdown()
+            self._server.server_close()
         if self._thread is not None:
             self._thread.join(timeout=1)
 

--- a/tests/test_gopro_controller.py
+++ b/tests/test_gopro_controller.py
@@ -30,6 +30,7 @@ def test_configure_and_preview():
         assert gopro.http_settings.hindsight.value is not None
         url = ctrl.start_preview(9000)
         assert url == 'http://127.0.0.1:9000/stream'
+        ctrl._gopro.streaming.stop()
 
 
 def test_start_hindsight_clip():


### PR DESCRIPTION
## Summary
- allow reuse of the TCP server address in the GoPro streaming stub
- close the server socket on shutdown
- stop streaming server in `test_configure_and_preview`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d250aa8a883218e544cff39bd1a52