### PR TITLE
Only export frames when person detected

### DIFF
--- a/pretraining/annotation/annotation_pipeline.py
+++ b/pretraining/annotation/annotation_pipeline.py
@@ -142,13 +142,17 @@ class PreLabelYOLO:
                 conf = float(b.conf[0].item())
                 if conf < self.conf_thr:
                     continue
-                x1, y1, x2, y2 = b.xyxy[0].tolist()
                 cls_id = int(b.cls[0].item())
+                label = self.names.get(cls_id, str(cls_id))
+                # Only keep detections of persons to avoid exporting every frame
+                if label.lower() != "person" and cls_id != 0:
+                    continue
+                x1, y1, x2, y2 = b.xyxy[0].tolist()
                 boxes.append(
                     {
                         "bbox": [x1, y1, x2, y2],
                         "cls": cls_id,
-                        "label": self.names.get(cls_id, str(cls_id)),
+                        "label": label,
                         "conf": conf,
                     }
                 )

--- a/tests/test_annotation_pipeline.py
+++ b/tests/test_annotation_pipeline.py
@@ -61,18 +61,20 @@ def test_prelabel_yolo_detection():
     class DummyModel:
         def __init__(self, boxes):
             self.boxes = boxes
+            self.names = {0: 'person', 1: 'car'}
+
         def __call__(self, frame):
             return [DummyResults(self.boxes)]
 
-    d_boxes = [DummyBox([0, 0, 10, 10], 0.8, 1), DummyBox([0, 0, 5, 5], 0.2, 2)]
+    d_boxes = [DummyBox([0, 0, 10, 10], 0.8, 0), DummyBox([0, 0, 5, 5], 0.9, 1)]
     with mock.patch.object(ap, 'YOLO', return_value=DummyModel(d_boxes)):
         yolo = ap.PreLabelYOLO(ap.YoloConfig(weights='x.pt', conf_thr=0.5))
         out = yolo.detect(np.zeros((10, 10, 3), dtype=np.uint8))
     assert out == [
         {
             'bbox': [0, 0, 10, 10],
-            'cls': 1,
-            'label': '1',
+            'cls': 0,
+            'label': 'person',
             'conf': 0.8,
         }
     ]


### PR DESCRIPTION
## Summary
- run annotation exporter only when YOLO finds a person
- adjust annotation pipeline tests to expect person-only filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e7f3bb2948321aed40c5ecfdffab9