### PR TITLE
Avoid automatic export in annotation GUI

### DIFF
--- a/pretraining/annotation/annotation_gui.py
+++ b/pretraining/annotation/annotation_gui.py
@@ -1,7 +1,6 @@
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox
-from pathlib import Path
 
 import cv2
 
@@ -11,36 +10,25 @@ from annotation_pipeline import (
     SamplingConfig,
     QualityConfig,
     YoloConfig,
-    ExportConfig,
     VidIngest,
     QualityFilter,
     PreLabelYOLO,
-    DatasetExporter,
 )
 
 
-def run_pipeline(video_path: str, output_dir: str) -> None:
-    """Run the annotation pipeline while displaying detection results.
+def run_pipeline(video_path: str, _output_dir: str) -> None:
+    """Run the annotation pipeline while displaying detection results."""
 
-    Parameters
-    ----------
-    video_path: str
-        Path to the input video.
-    output_dir: str
-        Directory where the dataset should be written.
-    """
     cfg = PipelineConfig(
         videos=[video_path],
         sampling=SamplingConfig(step=1),
         quality=QualityConfig(blur=0, luma_min=0, luma_max=500),
         yolo=YoloConfig(weights="yolov8s.onnx", conf_thr=0.25),
-        export=ExportConfig(output_dir=output_dir, format="yolo"),
     )
 
     ingest = VidIngest(cfg.videos, cfg.sampling)
     qf = QualityFilter(cfg.quality)
     yolo = PreLabelYOLO(cfg.yolo)
-    exporter = DatasetExporter(cfg.export)
 
     for item in ingest:
         frame = item["frame"]
@@ -53,9 +41,7 @@ def run_pipeline(video_path: str, output_dir: str) -> None:
         cv2.imshow("preview", frame)
         if cv2.waitKey(1) & 0xFF == ord("q"):
             break
-        exporter.save(item, boxes)
 
-    exporter.close()
     cv2.destroyAllWindows()
 
 
@@ -69,16 +55,30 @@ class AnnotationGUI:
         self.video_path = tk.StringVar()
         self.output_dir = tk.StringVar()
 
-        tk.Button(master, text="Select Video", command=self.select_video).pack(fill="x")
-        tk.Label(master, textvariable=self.video_path, anchor="w").pack(fill="x")
+        tk.Button(
+            master, text="Select Video", command=self.select_video
+        ).pack(fill="x")
+        tk.Label(
+            master, textvariable=self.video_path, anchor="w"
+        ).pack(fill="x")
 
-        tk.Button(master, text="Select Output", command=self.select_output).pack(fill="x")
-        tk.Label(master, textvariable=self.output_dir, anchor="w").pack(fill="x")
+        tk.Button(
+            master, text="Select Output", command=self.select_output
+        ).pack(fill="x")
+        tk.Label(
+            master, textvariable=self.output_dir, anchor="w"
+        ).pack(fill="x")
 
         tk.Button(master, text="Run", command=self.start).pack(fill="x")
 
     def select_video(self) -> None:
-        path = filedialog.askopenfilename(title="Select video", filetypes=[("Video files", "*.mp4;*.avi;*.mov;*.mkv"), ("All files", "*.*")])
+        path = filedialog.askopenfilename(
+            title="Select video",
+            filetypes=[
+                ("Video files", "*.mp4;*.avi;*.mov;*.mkv"),
+                ("All files", "*.*"),
+            ],
+        )
         if path:
             self.video_path.set(path)
 
@@ -91,10 +91,14 @@ class AnnotationGUI:
         video = self.video_path.get()
         output = self.output_dir.get()
         if not video or not output:
-            messagebox.showerror("Missing paths", "Please select video and output directory")
+            messagebox.showerror(
+                "Missing paths", "Please select video and output directory"
+            )
             return
 
-        thread = threading.Thread(target=run_pipeline, args=(video, output), daemon=True)
+        thread = threading.Thread(
+            target=run_pipeline, args=(video, output), daemon=True
+        )
         thread.start()
 
 


### PR DESCRIPTION
## Summary
- stop saving dataset items directly from the GUI preview
- tidy annotation GUI imports and formatting

## Testing
- `flake8 pretraining/annotation/annotation_gui.py`
- `pytest` *(fails: no images generated; Failed to read first frame)*

------
https://chatgpt.com/codex/tasks/task_e_688f0455b6d88321a5c6a34780392f42