### PR TITLE
Fix annotation GUI not exporting dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run a minimal interface to preview YOLO detections and save the resulting datase
 python pretraining/annotation/annotation_gui.py
 ```
 
-Choose a video and output directory, then press **Run** to watch the video with red bounding boxes while frames and labels are exported.
+Choose a video and output directory, then press **Run** to watch the video with green bounding boxes while frames and labels are exported.
 
 ## YOLOv8 Wakeboard Detector Training
 

--- a/pretraining/annotation/annotation_gui.py
+++ b/pretraining/annotation/annotation_gui.py
@@ -6,7 +6,7 @@ import annotation_pipeline as ap
 
 
 def run_pipeline(video_path: str, output_dir: str) -> None:
-    """Run the annotation pipeline while displaying detection results."""
+    """Run the annotation pipeline and export a labeled dataset."""
 
     cfg = ap.PipelineConfig(
         videos=[video_path],
@@ -15,7 +15,7 @@ def run_pipeline(video_path: str, output_dir: str) -> None:
         yolo=ap.YoloConfig(weights="yolov8s.onnx", conf_thr=0.25),
         export=ap.ExportConfig(output_dir=output_dir),
     )
-    ap.preview(cfg)
+    ap.run(cfg, show_preview=True)
 
 
 class AnnotationGUI:


### PR DESCRIPTION
## Summary
- allow `annotation_pipeline.run` to optionally preview detections while exporting
- make the annotation GUI export images/labels instead of only previewing
- document the preview color and add a regression test

## Testing
- `flake8 pretraining/annotation/annotation_pipeline.py pretraining/annotation/annotation_gui.py tests/test_annotation_pipeline.py` *(fails: E302, E501, E402, E301)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f1289d4f08321ad9bc6ad3a93ef7e