### PR TITLE
Remove FakeDriveService from production code

### DIFF
--- a/code/modules/GoogleDriveHandler.py
+++ b/code/modules/GoogleDriveHandler.py
@@ -8,7 +8,6 @@ from typing import Optional
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 import types
-import re
 from configparser import ConfigParser
 
 from ConfigurationHandler import ConfigurationHandler
@@ -50,76 +49,9 @@ class GoogleDriveHandler:
                 creds = None
 
         if creds is None:
-            class FakeDriveService:
-                """Minimal in-memory fake of the Google Drive service."""
-
-                def __init__(self):
-                    self.store = {}
-                    self.next_id = 1
-
-                def files(self):
-                    return self
-
-                def _parse_query(self, q):
-                    name = parent = None
-                    is_folder = False
-                    if q:
-                        m = re.search(r"name='([^']+)'", q)
-                        if m:
-                            name = m.group(1)
-                        m = re.search(r"'([^']+)' in parents", q)
-                        if m:
-                            parent = m.group(1)
-                        if "mimeType='application/vnd.google-apps.folder'" in q:
-                            is_folder = True
-                    return name, parent, is_folder
-
-                def list(self, q=None, fields=None):
-                    name, parent, is_folder = self._parse_query(q)
-                    files = []
-                    for entry in self.store.values():
-                        if name and entry['name'] != name:
-                            continue
-                        if parent and entry.get('parent') != parent:
-                            continue
-                        if is_folder and entry['mimeType'] != 'application/vnd.google-apps.folder':
-                            continue
-                        files.append({'id': entry['id'], 'name': entry['name']})
-                    return types.SimpleNamespace(execute=lambda: {'files': files})
-
-                def create(self, body=None, media_body=None, fields=None):
-                    file_id = f'id{self.next_id}'
-                    self.next_id += 1
-                    entry = {
-                        'id': file_id,
-                        'name': body.get('name'),
-                        'mimeType': body.get('mimeType', 'file'),
-                        'parent': (body.get('parents') or [None])[0],
-                    }
-                    if media_body is not None:
-                        path = getattr(media_body, 'filename', getattr(media_body, '_filename', None))
-                        with open(path, 'rb') as fh:
-                            entry['content'] = fh.read()
-                    self.store[file_id] = entry
-                    return types.SimpleNamespace(execute=lambda: {'id': file_id})
-
-                def update(self, fileId=None, media_body=None):
-                    entry = self.store[fileId]
-                    path = getattr(media_body, 'filename', getattr(media_body, '_filename', None))
-                    with open(path, 'rb') as fh:
-                        entry['content'] = fh.read()
-                    return types.SimpleNamespace(execute=lambda: None)
-
-                def get_media(self, fileId=None):
-                    content = self.store[fileId]['content']
-                    return types.SimpleNamespace(content=content)
-
-                def delete(self, fileId=None):
-                    self.store.pop(fileId, None)
-                    return types.SimpleNamespace(execute=lambda: None)
-
-            self.service = FakeDriveService()
-            return
+            raise RuntimeError(
+                "Google Drive credentials not found. Set the required environment variables or token file."
+            )
 
         # googleapiclient versions prior to 2.0 included a discovery_cache
         # module which was later removed. Newer versions of the library still


### PR DESCRIPTION
## Summary
- Remove in-memory FakeDriveService from GoogleDriveHandler
- Raise runtime error when Google Drive credentials are missing
- Drop unused import left by fake service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f1589a1908321855e47d8f923f222