### PR TITLE
refactor: simplify google drive authentication

### DIFF
--- a/tests/test_google_drive_authenticate.py
+++ b/tests/test_google_drive_authenticate.py
@@ -1,8 +1,6 @@
 import base64
-import pickle
 import sys
 from pathlib import Path
-import tempfile
 
 import pytest
 
@@ -12,7 +10,7 @@ sys.path.append(str(MODULE_DIR))
 from tests.stubs.google_api import setup_google_modules, DummyCreds
 
 
-def test_authenticate_uses_token_and_env(tmp_path, monkeypatch):
+def test_authenticate_uses_env(tmp_path, monkeypatch):
     captured = {}
     setup_google_modules(monkeypatch, captured)
     monkeypatch.chdir(tmp_path)
@@ -22,28 +20,19 @@ def test_authenticate_uses_token_and_env(tmp_path, monkeypatch):
     module = importlib.reload(module)
     GoogleDriveHandler = module.GoogleDriveHandler
 
-    token_creds = DummyCreds()
-    with open('token.pickle', 'wb') as fh:
-        pickle.dump(token_creds, fh)
-
     secret = base64.b64encode(b'{}').decode()
     monkeypatch.setenv('SECRET_ENV', secret)
 
-    paths = []
-    orig_ntf = tempfile.NamedTemporaryFile
-
-    def fake_ntf(*args, **kwargs):
-        kwargs.setdefault('delete', False)
-        tmp = orig_ntf(*args, **kwargs)
-        paths.append(Path(tmp.name))
-        return tmp
-
-    monkeypatch.setattr(module.tempfile, 'NamedTemporaryFile', fake_ntf)
+    monkeypatch.setattr(
+        module.service_account.Credentials,
+        'from_service_account_info',
+        lambda *a, **k: DummyCreds(),
+        raising=False,
+    )
 
     handler = GoogleDriveHandler({'GOOGLE_DRIVE': {'secret_key_name': 'SECRET_ENV'}})
     handler._authenticate()
 
     assert handler.service == 'service'
     assert isinstance(captured['creds'], DummyCreds)
-    assert paths and not paths[0].exists()
 


### PR DESCRIPTION
## Summary
- streamline Google Drive auth by decoding service account secrets directly from environment variables
- expand docstrings and comments for clearer intent across GoogleDriveHandler
- adjust authentication test to validate environment-based credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd15c3cf48321b4b8632a015cbbe2