### PR TITLE
Add spline interpolation for annotation pipeline and GUI

### DIFF
--- a/pretraining/annotation/annotation_gui.py
+++ b/pretraining/annotation/annotation_gui.py
@@ -6,7 +6,27 @@ import annotation_pipeline as ap
 
 
 def run_pipeline(video_path: str, output_dir: str) -> None:
-    """Run the annotation pipeline and export a labeled dataset."""
+    """Execute the pipeline for one video and export a dataset.
+
+    Purpose
+    -------
+    Construct a configuration and invoke :func:`annotation_pipeline.run` so
+    that frames, labels and an interpolated trajectory are generated for the
+    supplied video.
+
+    Inputs
+    ------
+    video_path: str
+        Path to the source video file.
+    output_dir: str
+        Directory where the dataset will be written.
+
+    Outputs
+    -------
+    None
+        Files are written to ``output_dir`` and the preview window pauses on
+        the final frame awaiting a keypress.
+    """
 
     cfg = ap.PipelineConfig(
         videos=[video_path],
@@ -15,13 +35,27 @@ def run_pipeline(video_path: str, output_dir: str) -> None:
         yolo=ap.YoloConfig(weights="yolov8s.onnx", conf_thr=0.25),
         export=ap.ExportConfig(output_dir=output_dir),
     )
+    # ``show_preview`` enables the trajectory overlay and keypress pause at the
+    # end of processing, giving users a chance to validate results.
     ap.run(cfg, show_preview=True)
 
 
 class AnnotationGUI:
-    """Minimal technical GUI for running the annotation pipeline."""
+    """Simple Tkinter front-end for the annotation pipeline."""
 
     def __init__(self, master: tk.Tk):
+        """Create widgets and bind actions.
+
+        Parameters
+        ----------
+        master: tk.Tk
+            Root Tk instance used to place widgets.
+
+        Outputs
+        -------
+        None
+            Widgets are attached to ``master`` and await user interaction.
+        """
         self.master = master
         master.title("Annotation Pipeline")
 
@@ -45,6 +79,7 @@ class AnnotationGUI:
         tk.Button(master, text="Run", command=self.start).pack(fill="x")
 
     def select_video(self) -> None:
+        """Prompt the user to select a video file."""
         path = filedialog.askopenfilename(
             title="Select video",
             filetypes=[
@@ -56,11 +91,13 @@ class AnnotationGUI:
             self.video_path.set(path)
 
     def select_output(self) -> None:
+        """Prompt the user to select an output directory."""
         path = filedialog.askdirectory(title="Select output directory")
         if path:
             self.output_dir.set(path)
 
     def start(self) -> None:
+        """Launch the pipeline in a background thread."""
         video = self.video_path.get()
         output = self.output_dir.get()
         if not video or not output:
@@ -69,6 +106,7 @@ class AnnotationGUI:
             )
             return
 
+        # Running in a thread keeps the GUI responsive during processing.
         thread = threading.Thread(
             target=run_pipeline, args=(video, output), daemon=True
         )


### PR DESCRIPTION
## Summary
- Estimate intermediate person positions using cubic spline interpolation and save interpolated bounding boxes
- Show full trajectory on last frame and wait for user confirmation in preview mode
- Document GUI pipeline runner and keep UI responsive while processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e3b0fb8c8321bcb1f264e53f585d