### PR TITLE
feat: add selectable Google Drive auth modes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -84,3 +84,4 @@ TCX_dummy_satellites = 99
 account = BearVisionApp@gmail.com
 secret_key_name = GOOGLE_CREDENTIALS_JSON
 root_folder = bearvison_files
+auth_mode = user

--- a/tests/stubs/google_api.py
+++ b/tests/stubs/google_api.py
@@ -4,7 +4,10 @@ import re
 
 
 class DummyCreds:
-    pass
+    """Simple credentials object used by stubs."""
+
+    def to_json(self):  # pragma: no cover - trivial
+        return "{}"
 
 
 class DummyMediaFileUpload:
@@ -32,13 +35,37 @@ def install_google_stubs():
     apiclient_mod = types.ModuleType('googleapiclient')
     disc_mod = types.ModuleType('googleapiclient.discovery')
     http_mod = types.ModuleType('googleapiclient.http')
+    errors_mod = types.ModuleType('googleapiclient.errors')
     disc_mod.build = lambda *a, **k: None
     http_mod.MediaFileUpload = DummyMediaFileUpload
     http_mod.MediaIoBaseDownload = DummyMediaIoBaseDownload
+    errors_mod.HttpError = type('HttpError', (Exception,), {})
 
     sys.modules['googleapiclient'] = apiclient_mod
     sys.modules['googleapiclient.discovery'] = disc_mod
     sys.modules['googleapiclient.http'] = http_mod
+    sys.modules['googleapiclient.errors'] = errors_mod
+
+    # Stub modules for authentication flows so the handler can be imported
+    oauthlib_mod = types.ModuleType('google_auth_oauthlib')
+    flow_mod = types.ModuleType('google_auth_oauthlib.flow')
+    flow_mod.InstalledAppFlow = types.SimpleNamespace(from_client_config=lambda *a, **k: DummyCreds())
+    oauthlib_mod.flow = flow_mod
+    sys.modules['google_auth_oauthlib'] = oauthlib_mod
+    sys.modules['google_auth_oauthlib.flow'] = flow_mod
+
+    oauth2_mod = types.ModuleType('google.oauth2')
+    service_mod = types.ModuleType('google.oauth2.service_account')
+
+    class _Creds:
+        @staticmethod
+        def from_service_account_info(*a, **k):
+            return DummyCreds()
+
+    service_mod.Credentials = _Creds
+    oauth2_mod.service_account = service_mod
+    sys.modules['google.oauth2'] = oauth2_mod
+    sys.modules['google.oauth2.service_account'] = service_mod
 
 
 class FakeDriveService:

--- a/tests/test_google_drive_authenticate.py
+++ b/tests/test_google_drive_authenticate.py
@@ -1,5 +1,8 @@
+"""Tests for the GoogleDriveHandler authentication logic."""
+
 import base64
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -10,7 +13,8 @@ sys.path.append(str(MODULE_DIR))
 from tests.stubs.google_api import setup_google_modules, DummyCreds
 
 
-def test_authenticate_uses_env(tmp_path, monkeypatch):
+def test_authenticate_service_account(tmp_path, monkeypatch):
+    """Ensure service account credentials are used when configured."""
     captured = {}
     setup_google_modules(monkeypatch, captured)
     monkeypatch.chdir(tmp_path)
@@ -30,7 +34,47 @@ def test_authenticate_uses_env(tmp_path, monkeypatch):
         raising=False,
     )
 
-    handler = GoogleDriveHandler({'GOOGLE_DRIVE': {'secret_key_name': 'SECRET_ENV'}})
+    handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
+        'secret_key_name': 'SECRET_ENV',
+        'auth_mode': 'service',
+    }})
+    handler._authenticate()
+
+    assert handler.service == 'service'
+    assert isinstance(captured['creds'], DummyCreds)
+
+
+def test_authenticate_user_flow(tmp_path, monkeypatch):
+    """Verify OAuth user flow is used when auth_mode='user'."""
+    captured = {}
+    setup_google_modules(monkeypatch, captured)
+    monkeypatch.chdir(tmp_path)
+
+    import importlib
+    module = importlib.import_module('GoogleDriveHandler')
+    module = importlib.reload(module)
+    GoogleDriveHandler = module.GoogleDriveHandler
+
+    secret = base64.b64encode(b'{}').decode()
+    monkeypatch.setenv('SECRET_ENV', secret)
+
+    class DummyFlow:
+        """Minimal stand-in for InstalledAppFlow."""
+
+        def run_local_server(self, port=0):  # pragma: no cover - simple stub
+            return DummyCreds()
+
+    def fake_from_client_config(*a, **k):  # pragma: no cover - simple stub
+        return DummyFlow()
+
+    monkeypatch.setattr(module, 'InstalledAppFlow', types.SimpleNamespace(
+        from_client_config=fake_from_client_config
+    ))
+
+    handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
+        'secret_key_name': 'SECRET_ENV',
+        'auth_mode': 'user',
+    }})
     handler._authenticate()
 
     assert handler.service == 'service'


### PR DESCRIPTION
## Summary
- allow GoogleDriveHandler to authenticate either with OAuth 2.0 user flow or a service account
- expose new `auth_mode` option in config to toggle between user and service credentials
- expand test stubs and coverage for both authentication approaches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891063a390c83219de847189a5d782f