### PR TITLE
Add google-auth-oauthlib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ lxml
 opencv-python-headless
 google-auth
 google-api-python-client
+google-auth-oauthlib
 open_gopro


### PR DESCRIPTION
## Summary
- add google-auth-oauthlib to requirements to satisfy GoogleDriveHandler dependency

## Testing
- `pytest tests/test_google_drive_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68910eaa78c88321b1010dc291252f3b