### PR TITLE
Support split Google Drive credential env vars

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -83,5 +83,6 @@ TCX_dummy_satellites = 99
 [GOOGLE_DRIVE]
 account = BearVisionApp@gmail.com
 secret_key_name = GOOGLE_CREDENTIALS_JSON
+secret_key_name_2 = GOOGLE_CREDENTIALS_B64_2
 root_folder = bearvison_files
 auth_mode = service


### PR DESCRIPTION
## Summary
- allow Google Drive credentials to span two env vars and concatenate before base64 decoding
- add `secret_key_name_2` option in config
- test credential handling when split into multiple env vars

## Testing
- `pytest tests/test_google_drive_authenticate.py tests/test_google_drive_handler.py tests/test_google_drive.py tests/test_google_credentials_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68911e874c808321bf96422782e296b5