### PR TITLE
Require explicit Google Drive credential keys

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -82,7 +82,7 @@ TCX_dummy_hdop = 0.1
 TCX_dummy_satellites = 99
 [GOOGLE_DRIVE]
 account = BearVisionApp@gmail.com
-secret_key_name = GOOGLE_CREDENTIALS_JSON
+secret_key_name = GOOGLE_CREDENTIALS_B64
 secret_key_name_2 = GOOGLE_CREDENTIALS_B64_2
 root_folder = bearvison_files
 auth_mode = service

--- a/tests/test_google_credentials_b64.py
+++ b/tests/test_google_credentials_b64.py
@@ -1,0 +1,17 @@
+import os
+
+
+def test_google_credentials_b64_defined_and_not_unset():
+    """
+    Purpose:
+        Verify that the ``GOOGLE_CREDENTIALS_B64`` environment variable is set
+        to a meaningful value.
+    Inputs:
+        None.
+    Outputs:
+        None; assertions fail if the variable is missing or carries the sentinel
+        value ``UNSET``.
+    """
+    value = os.getenv('GOOGLE_CREDENTIALS_B64')
+    assert value is not None and value != '', 'GOOGLE_CREDENTIALS_B64 should be set'
+    assert value != 'UNSET', 'GOOGLE_CREDENTIALS_B64 should not be UNSET'

--- a/tests/test_google_drive.py
+++ b/tests/test_google_drive.py
@@ -29,8 +29,18 @@ except Exception:
     reason="Google Drive dependencies missing or incompatible",
 )
 def test_google_drive_upload_download(tmp_path):
-    if not os.getenv('GOOGLE_CREDENTIALS_JSON'):
-        pytest.skip('GOOGLE_CREDENTIALS_JSON not set')
+    """
+    Purpose:
+        Upload and then download a file to verify round-trip behavior against
+        Google Drive. Network interactions are skipped in normal test runs.
+    Inputs:
+        tmp_path (Path): Temporary directory fixture provided by pytest.
+    Outputs:
+        None; assertions validate that the uploaded content matches the
+        downloaded content.
+    """
+    if not os.getenv('GOOGLE_CREDENTIALS_B64'):
+        pytest.skip('GOOGLE_CREDENTIALS_B64 not set')
 
     cfg_path = ROOT / 'config.ini'
     ConfigurationHandler.read_config_file(str(cfg_path))

--- a/tests/test_google_drive_authenticate.py
+++ b/tests/test_google_drive_authenticate.py
@@ -36,6 +36,7 @@ def test_authenticate_service_account(tmp_path, monkeypatch):
 
     handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
         'secret_key_name': 'SECRET_ENV',
+        'secret_key_name_2': 'SECRET_ENV2',  # explicit second name required
         'auth_mode': 'service',
     }})
     handler._authenticate()
@@ -73,6 +74,7 @@ def test_authenticate_user_flow(tmp_path, monkeypatch):
 
     handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
         'secret_key_name': 'SECRET_ENV',
+        'secret_key_name_2': 'SECRET_ENV2',  # explicit second name required
         'auth_mode': 'user',
     }})
     handler._authenticate()


### PR DESCRIPTION
## Summary
- Default Google Drive credential config now points to `GOOGLE_CREDENTIALS_B64`
- GoogleDriveHandler requires explicit `secret_key_name` and `secret_key_name_2` and raises if missing
- Tests updated for the new configuration and environment variable names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933b3bc60c8321927892e9468a81a7