### PR TITLE
Require primary Google Drive credential key

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -82,7 +82,7 @@ TCX_dummy_hdop = 0.1
 TCX_dummy_satellites = 99
 [GOOGLE_DRIVE]
 account = BearVisionApp@gmail.com
-secret_key_name = GOOGLE_CREDENTIALS_JSON
+secret_key_name = GOOGLE_CREDENTIALS_B64
 secret_key_name_2 = GOOGLE_CREDENTIALS_B64_2
 root_folder = bearvison_files
 auth_mode = service

--- a/tests/test_google_credentials_b64.py
+++ b/tests/test_google_credentials_b64.py
@@ -1,0 +1,17 @@
+import os
+
+
+def test_google_credentials_b64_defined_and_not_unset():
+    """
+    Purpose:
+        Verify that the ``GOOGLE_CREDENTIALS_B64`` environment variable is set
+        to a meaningful value.
+    Inputs:
+        None.
+    Outputs:
+        None; assertions fail if the variable is missing or carries the sentinel
+        value ``UNSET``.
+    """
+    value = os.getenv('GOOGLE_CREDENTIALS_B64')
+    assert value is not None and value != '', 'GOOGLE_CREDENTIALS_B64 should be set'
+    assert value != 'UNSET', 'GOOGLE_CREDENTIALS_B64 should not be UNSET'

--- a/tests/test_google_drive.py
+++ b/tests/test_google_drive.py
@@ -29,8 +29,18 @@ except Exception:
     reason="Google Drive dependencies missing or incompatible",
 )
 def test_google_drive_upload_download(tmp_path):
-    if not os.getenv('GOOGLE_CREDENTIALS_JSON'):
-        pytest.skip('GOOGLE_CREDENTIALS_JSON not set')
+    """
+    Purpose:
+        Upload and then download a file to verify round-trip behavior against
+        Google Drive. Network interactions are skipped in normal test runs.
+    Inputs:
+        tmp_path (Path): Temporary directory fixture provided by pytest.
+    Outputs:
+        None; assertions validate that the uploaded content matches the
+        downloaded content.
+    """
+    if not os.getenv('GOOGLE_CREDENTIALS_B64'):
+        pytest.skip('GOOGLE_CREDENTIALS_B64 not set')
 
     cfg_path = ROOT / 'config.ini'
     ConfigurationHandler.read_config_file(str(cfg_path))

--- a/tests/test_google_drive_authenticate.py
+++ b/tests/test_google_drive_authenticate.py
@@ -14,7 +14,16 @@ from tests.stubs.google_api import setup_google_modules, DummyCreds
 
 
 def test_authenticate_service_account(tmp_path, monkeypatch):
-    """Ensure service account credentials are used when configured."""
+    """
+    Purpose:
+        Ensure service account authentication succeeds even when the secondary
+        credential environment variable is absent.
+    Inputs:
+        tmp_path (Path): Temporary directory for isolating test artifacts.
+        monkeypatch: Pytest fixture to modify environment and modules.
+    Outputs:
+        None; assertions validate that the service object is created.
+    """
     captured = {}
     setup_google_modules(monkeypatch, captured)
     monkeypatch.chdir(tmp_path)
@@ -36,6 +45,7 @@ def test_authenticate_service_account(tmp_path, monkeypatch):
 
     handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
         'secret_key_name': 'SECRET_ENV',
+        'secret_key_name_2': 'SECRET_ENV2',  # env var not set on purpose
         'auth_mode': 'service',
     }})
     handler._authenticate()
@@ -44,8 +54,42 @@ def test_authenticate_service_account(tmp_path, monkeypatch):
     assert isinstance(captured['creds'], DummyCreds)
 
 
+def test_missing_primary_secret_raises(tmp_path, monkeypatch):
+    """
+    Purpose:
+        Verify that omitting ``secret_key_name`` from the configuration triggers
+        a ``KeyError`` as the primary credential is mandatory.
+    Inputs:
+        tmp_path (Path): Temporary directory for test isolation.
+        monkeypatch: Fixture used to stub google modules.
+    Outputs:
+        None; the test passes if ``KeyError`` is raised.
+    """
+    captured = {}
+    setup_google_modules(monkeypatch, captured)
+    monkeypatch.chdir(tmp_path)
+
+    import importlib
+    module = importlib.import_module('GoogleDriveHandler')
+    module = importlib.reload(module)
+    GoogleDriveHandler = module.GoogleDriveHandler
+
+    handler = GoogleDriveHandler({'GOOGLE_DRIVE': {}})
+    with pytest.raises(KeyError):
+        handler._authenticate()
+
+
 def test_authenticate_user_flow(tmp_path, monkeypatch):
-    """Verify OAuth user flow is used when auth_mode='user'."""
+    """
+    Purpose:
+        Verify OAuth user flow is used when `auth_mode` is set to ``user`` and
+        no secondary credential name is configured.
+    Inputs:
+        tmp_path (Path): Temporary directory for isolation.
+        monkeypatch: Pytest fixture for patching modules and environment.
+    Outputs:
+        None; assertions check that authentication completes.
+    """
     captured = {}
     setup_google_modules(monkeypatch, captured)
     monkeypatch.chdir(tmp_path)
@@ -67,9 +111,11 @@ def test_authenticate_user_flow(tmp_path, monkeypatch):
     def fake_from_client_config(*a, **k):  # pragma: no cover - simple stub
         return DummyFlow()
 
-    monkeypatch.setattr(module, 'InstalledAppFlow', types.SimpleNamespace(
-        from_client_config=fake_from_client_config
-    ))
+    monkeypatch.setattr(
+        module,
+        'InstalledAppFlow',
+        types.SimpleNamespace(from_client_config=fake_from_client_config),
+    )
 
     handler = GoogleDriveHandler({'GOOGLE_DRIVE': {
         'secret_key_name': 'SECRET_ENV',


### PR DESCRIPTION
## Summary
- Treat the secondary Google Drive credential key as optional, defaulting to an empty string
- Add coverage for missing primary key and ensure service/user auth flows work without the secondary key

## Testing
- `pytest tests/test_google_drive_authenticate.py tests/test_google_credentials_b64.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68933b3bc60c8321927892e9468a81a7