### PR TITLE
feat: stream frame previews in annotation GUI

### DIFF
--- a/pretraining/annotation/sample_config.yaml
+++ b/pretraining/annotation/sample_config.yaml
@@ -1,6 +1,7 @@
 videos:
   - path/to/video1.mp4
 detection_gap_timeout_s: 3.0
+preview_scaling: 0.2
 sampling:
   fps: 2.0
 quality:


### PR DESCRIPTION
## Summary
- add `preview_scaling` config and wire into pipeline status
- stream per-frame preview images via callback
- disable RUN button during processing and show scaled preview pane

## Testing
- `GOOGLE_CREDENTIALS_JSON=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893adaf833483218b5a7c6ac9e072af