### PR TITLE
Fix annotation pipeline silently skipping invalid videos

### DIFF
--- a/pretraining/annotation/annotation_gui.py
+++ b/pretraining/annotation/annotation_gui.py
@@ -216,9 +216,15 @@ class AnnotationGUI:
         -------
         None
             After completion the Run button is re-enabled on the main thread.
+            Any exceptions are surfaced via a message box for visibility.
         """
         try:
             run_pipeline(self.base_cfg, video, output, self.on_frame)
+        except Exception as exc:  # pragma: no cover - GUI presentation
+            # Without this handler users receive no feedback when the pipeline
+            # fails (e.g. due to missing video/weights).  Showing a message box
+            # makes the failure explicit and keeps the GUI responsive.
+            self.master.after(0, lambda: messagebox.showerror("Pipeline error", str(exc)))
         finally:
             # ``after`` hands control back to the Tk main loop so widget state is
             # manipulated safely from the GUI thread. We also ensure any preview

--- a/pretraining/annotation/annotation_pipeline.py
+++ b/pretraining/annotation/annotation_pipeline.py
@@ -281,11 +281,19 @@ class VidIngest:
         Iterator[dict]
             Each dictionary contains the video path, frame index and image
             array for sampled frames.
+
+        Raises
+        ------
+        FileNotFoundError
+            If a video cannot be opened, likely due to an invalid path or
+            unsupported codec.
         """
         for video_path in self.videos:
             cap = cv2.VideoCapture(video_path)
             if not cap.isOpened():
-                continue
+                # Failing silently makes the pipeline appear successful with no output;
+                # raising surfaces path or codec issues early for easier debugging.
+                raise FileNotFoundError(f"Cannot open video: {video_path}")
             # Derive a stride based on desired FPS; fall back to a fixed step for
             # robustness when metadata is missing.
             orig_fps = cap.get(cv2.CAP_PROP_FPS) or 30


### PR DESCRIPTION
## Summary
- Raise `FileNotFoundError` when a video fails to open in `VidIngest` to avoid silent no-ops
- Show a message box for pipeline errors in the annotation GUI thread

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'from_settings_dictionary')*

------
https://chatgpt.com/codex/tasks/task_e_6893be3174708321b13a51bc2954b0d9