### PR TITLE
Fix Android CI: Update Gradle plugin to support Java 21

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.10'
     implementation 'com.google.android.gms:play-services-auth:20.5.0'
     implementation 'com.google.api-client:google-api-client-android:1.34.2'
     implementation 'com.google.apis:google-api-services-drive:v3-rev20240120-2.0.0'

--- a/android_app/build.gradle
+++ b/android_app/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
+        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10'
     }
 }
 


### PR DESCRIPTION
Fixes the persistent Android CI build failure by updating Android Gradle Plugin to version that supports Java 21.

## Changes
- Update Android Gradle Plugin from 8.0.2 to 8.1.4
- Update Kotlin plugin from 1.8.22 to 1.9.10
- Update Kotlin stdlib to match plugin version

## Root Cause
The ClassNotFoundException occurred because AGP 8.0.2 is incompatible with Java 21, causing Gradle wrapper startup failures.

Fixes #112

Generated with [Claude Code](https://claude.ai/code)