### PR TITLE
Add PySide6 GUI for YOLOv8 training

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,13 @@ pytest -v
 ### Machine Learning Pipeline
 ```bash
 # Annotation GUI for creating training datasets
-python pretraining/annotation/annotation_gui.py
+python pretraining/annotation/annotation_gui_pyqt.py
 
-# Train YOLOv8 model on custom dataset
+# Train YOLOv8 model on custom dataset (CLI)
 python pretraining/train_yolo.py /path/to/dataset --epochs 100 --batch 8 --onnx-out wakeboard.onnx
+
+# Training GUI for easy YOLO model fine-tuning
+python pretraining/train_yolo_gui.py
 ```
 
 ## Architecture Overview

--- a/pretraining/train_config.yaml
+++ b/pretraining/train_config.yaml
@@ -1,0 +1,16 @@
+# YOLOv8 Training Configuration
+# This file contains default parameters for the YOLO training GUI
+
+training:
+  model: "yolov8x.pt"           # Base model weights
+  epochs: 50                    # Number of training epochs
+  batch: 16                     # Training batch size  
+  imgsz: 640                    # Image size for training
+  device: null                  # Device to use (null for auto-detection)
+  val_ratio: 0.2               # Validation split ratio
+  onnx_out: "yolov8_finetuned.onnx"  # Output path for ONNX model
+
+paths:
+  data_dir: ""                  # Directory with images and YOLO .txt labels
+  last_image_dir: ""           # Last selected image directory
+  last_output_dir: ""          # Last selected output directory

--- a/pretraining/train_gui_launcher.py
+++ b/pretraining/train_gui_launcher.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Simple launcher script for the YOLOv8 training GUI."""
+
+import sys
+from pathlib import Path
+
+# Add the parent directory to Python path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from train_yolo_gui import main
+
+if __name__ == "__main__":
+    main()

--- a/pretraining/train_yolo_gui.py
+++ b/pretraining/train_yolo_gui.py
@@ -1,0 +1,497 @@
+"""PySide6-based GUI for YOLOv8 training."""
+
+import sys
+import os
+import threading
+import subprocess
+import json
+from pathlib import Path
+from typing import Optional, Dict, Any
+import yaml
+
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QLineEdit, QPushButton, QFrame, QFileDialog, QMessageBox,
+    QSplitter, QScrollArea, QTextEdit, QSpinBox, QDoubleSpinBox,
+    QComboBox, QGroupBox, QFormLayout, QProgressBar
+)
+from PySide6.QtCore import Qt, QTimer, Signal, QObject, QThread
+from PySide6.QtGui import QFont, QTextCursor
+
+
+class LogSignals(QObject):
+    """Signals for thread-safe log updates."""
+    log_updated = Signal(str)
+    training_finished = Signal(bool)  # True for success, False for error
+
+
+class TrainingWorker(QThread):
+    """Worker thread to run training subprocess and capture output."""
+    
+    def __init__(self, train_script_path: str, args: list):
+        super().__init__()
+        self.train_script_path = train_script_path
+        self.args = args
+        self.signals = LogSignals()
+        
+    def run(self):
+        """Execute training subprocess and emit log updates."""
+        try:
+            cmd = [sys.executable, self.train_script_path] + self.args
+            self.signals.log_updated.emit(f"Executing: {' '.join(cmd)}\n")
+            
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                bufsize=1
+            )
+            
+            # Read output line by line
+            for line in iter(process.stdout.readline, ''):
+                if line:
+                    self.signals.log_updated.emit(line)
+            
+            process.wait()
+            
+            if process.returncode == 0:
+                self.signals.log_updated.emit("\n✅ Training completed successfully!\n")
+                self.signals.training_finished.emit(True)
+            else:
+                self.signals.log_updated.emit(f"\n❌ Training failed with exit code {process.returncode}\n")
+                self.signals.training_finished.emit(False)
+                
+        except Exception as e:
+            self.signals.log_updated.emit(f"\n❌ Error running training: {str(e)}\n")
+            self.signals.training_finished.emit(False)
+
+
+class TrainYoloGUI(QMainWindow):
+    """PySide6 GUI for YOLOv8 training."""
+    
+    def __init__(self):
+        """Initialize the training GUI."""
+        super().__init__()
+        self.setWindowTitle("YOLOv8 Training GUI")
+        self.setGeometry(100, 100, 1200, 800)
+        
+        # Configuration management
+        self.config_path = Path(__file__).parent / "train_config.yaml"
+        self.config = self.load_config()
+        
+        # Training worker
+        self.training_worker = None
+        self.is_training = False
+        
+        # Initialize UI
+        self.init_ui()
+        self.populate_from_config()
+        
+    def load_config(self) -> Dict[str, Any]:
+        """Load configuration from YAML file."""
+        if self.config_path.exists():
+            try:
+                with open(self.config_path, 'r') as f:
+                    return yaml.safe_load(f)
+            except Exception as e:
+                print(f"Warning: Could not load config: {e}")
+        
+        # Return default configuration
+        return {
+            'training': {
+                'model': 'yolov8x.pt',
+                'epochs': 50,
+                'batch': 16,
+                'imgsz': 640,
+                'device': None,
+                'val_ratio': 0.2,
+                'onnx_out': 'yolov8_finetuned.onnx'
+            },
+            'paths': {
+                'data_dir': '',
+                'last_image_dir': '',
+                'last_output_dir': ''
+            }
+        }
+    
+    def save_config(self):
+        """Save current configuration to YAML file."""
+        try:
+            # Update config with current values
+            self.config['training']['model'] = self.model_combo.currentText()
+            self.config['training']['epochs'] = self.epochs_spin.value()
+            self.config['training']['batch'] = self.batch_spin.value()
+            self.config['training']['imgsz'] = self.imgsz_spin.value()
+            self.config['training']['device'] = self.device_edit.text() or None
+            self.config['training']['val_ratio'] = self.val_ratio_spin.value()
+            self.config['training']['onnx_out'] = self.onnx_out_edit.text()
+            self.config['paths']['data_dir'] = self.data_dir_edit.text()
+            
+            with open(self.config_path, 'w') as f:
+                yaml.safe_dump(self.config, f, default_flow_style=False)
+        except Exception as e:
+            print(f"Warning: Could not save config: {e}")
+    
+    def init_ui(self):
+        """Initialize the user interface."""
+        # Central widget and main layout
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+        main_layout = QHBoxLayout(central_widget)
+        
+        # Create main splitter
+        main_splitter = QSplitter(Qt.Horizontal)
+        main_layout.addWidget(main_splitter)
+        
+        # Left panel for controls
+        left_panel = QWidget()
+        left_panel.setFixedWidth(400)
+        left_layout = QVBoxLayout(left_panel)
+        
+        # Data directory selection
+        data_group = QGroupBox("Dataset Configuration")
+        data_layout = QVBoxLayout(data_group)
+        
+        # Data directory
+        data_dir_layout = QHBoxLayout()
+        data_dir_layout.addWidget(QLabel("Images & Labels Dir:"))
+        self.data_dir_edit = QLineEdit()
+        self.data_dir_edit.setPlaceholderText("Select directory containing images and .txt labels")
+        data_dir_layout.addWidget(self.data_dir_edit)
+        
+        self.select_data_btn = QPushButton("Browse...")
+        self.select_data_btn.clicked.connect(self.select_data_directory)
+        data_dir_layout.addWidget(self.select_data_btn)
+        data_layout.addLayout(data_dir_layout)
+        
+        left_layout.addWidget(data_group)
+        
+        # Training parameters
+        params_group = QGroupBox("Training Parameters")
+        params_layout = QFormLayout(params_group)
+        
+        # Model selection
+        self.model_combo = QComboBox()
+        self.model_combo.addItems(['yolov8n.pt', 'yolov8s.pt', 'yolov8m.pt', 'yolov8l.pt', 'yolov8x.pt'])
+        self.model_combo.setEditable(True)
+        params_layout.addRow("Model:", self.model_combo)
+        
+        # Epochs
+        self.epochs_spin = QSpinBox()
+        self.epochs_spin.setRange(1, 1000)
+        self.epochs_spin.setValue(50)
+        params_layout.addRow("Epochs:", self.epochs_spin)
+        
+        # Batch size
+        self.batch_spin = QSpinBox()
+        self.batch_spin.setRange(1, 128)
+        self.batch_spin.setValue(16)
+        params_layout.addRow("Batch Size:", self.batch_spin)
+        
+        # Image size
+        self.imgsz_spin = QSpinBox()
+        self.imgsz_spin.setRange(32, 2048)
+        self.imgsz_spin.setSingleStep(32)
+        self.imgsz_spin.setValue(640)
+        params_layout.addRow("Image Size:", self.imgsz_spin)
+        
+        # Device
+        self.device_edit = QLineEdit()
+        self.device_edit.setPlaceholderText("Leave empty for auto-detection")
+        params_layout.addRow("Device:", self.device_edit)
+        
+        # Validation ratio
+        self.val_ratio_spin = QDoubleSpinBox()
+        self.val_ratio_spin.setRange(0.0, 1.0)
+        self.val_ratio_spin.setSingleStep(0.1)
+        self.val_ratio_spin.setValue(0.2)
+        self.val_ratio_spin.setDecimals(2)
+        params_layout.addRow("Val Ratio:", self.val_ratio_spin)
+        
+        # ONNX output path
+        self.onnx_out_edit = QLineEdit()
+        self.onnx_out_edit.setText("yolov8_finetuned.onnx")
+        params_layout.addRow("ONNX Output:", self.onnx_out_edit)
+        
+        left_layout.addWidget(params_group)
+        
+        # Control buttons
+        control_layout = QVBoxLayout()
+        
+        self.save_config_btn = QPushButton("Save Configuration")
+        self.save_config_btn.clicked.connect(self.save_config)
+        control_layout.addWidget(self.save_config_btn)
+        
+        self.start_training_btn = QPushButton("Start Training")
+        self.start_training_btn.clicked.connect(self.start_training)
+        self.start_training_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #4CAF50;
+                color: white;
+                font-weight: bold;
+                padding: 10px;
+                border-radius: 5px;
+            }
+            QPushButton:hover {
+                background-color: #45a049;
+            }
+            QPushButton:disabled {
+                background-color: #cccccc;
+                color: #666666;
+            }
+        """)
+        control_layout.addWidget(self.start_training_btn)
+        
+        self.stop_training_btn = QPushButton("Stop Training")
+        self.stop_training_btn.clicked.connect(self.stop_training)
+        self.stop_training_btn.setEnabled(False)
+        self.stop_training_btn.setStyleSheet("""
+            QPushButton {
+                background-color: #f44336;
+                color: white;
+                font-weight: bold;
+                padding: 10px;
+                border-radius: 5px;
+            }
+            QPushButton:hover {
+                background-color: #da190b;
+            }
+            QPushButton:disabled {
+                background-color: #cccccc;
+                color: #666666;
+            }
+        """)
+        control_layout.addWidget(self.stop_training_btn)
+        
+        left_layout.addLayout(control_layout)
+        
+        # Status
+        self.status_label = QLabel("Ready")
+        self.status_label.setStyleSheet("QLabel { font-weight: bold; padding: 5px; }")
+        left_layout.addWidget(self.status_label)
+        
+        # Progress bar
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setVisible(False)
+        left_layout.addWidget(self.progress_bar)
+        
+        left_layout.addStretch()
+        
+        # Add left panel to splitter
+        main_splitter.addWidget(left_panel)
+        
+        # Right panel - Real-time log display
+        log_panel = QFrame()
+        log_layout = QVBoxLayout(log_panel)
+        
+        log_label = QLabel("Training Log")
+        log_label.setFont(QFont("Arial", 12, QFont.Bold))
+        log_layout.addWidget(log_label)
+        
+        self.log_text = QTextEdit()
+        self.log_text.setReadOnly(True)
+        self.log_text.setFont(QFont("Consolas", 9))
+        self.log_text.setStyleSheet("""
+            QTextEdit {
+                background-color: #1e1e1e;
+                color: #d4d4d4;
+                border: 1px solid #555;
+            }
+        """)
+        log_layout.addWidget(self.log_text)
+        
+        # Clear log button
+        self.clear_log_btn = QPushButton("Clear Log")
+        self.clear_log_btn.clicked.connect(self.clear_log)
+        log_layout.addWidget(self.clear_log_btn)
+        
+        # Add log panel to splitter
+        main_splitter.addWidget(log_panel)
+        
+        # Set splitter proportions
+        main_splitter.setSizes([400, 800])
+        
+    def populate_from_config(self):
+        """Populate UI fields from loaded configuration."""
+        training_config = self.config.get('training', {})
+        paths_config = self.config.get('paths', {})
+        
+        # Set training parameters
+        model = training_config.get('model', 'yolov8x.pt')
+        if model in [self.model_combo.itemText(i) for i in range(self.model_combo.count())]:
+            self.model_combo.setCurrentText(model)
+        else:
+            self.model_combo.setCurrentText(model)
+            
+        self.epochs_spin.setValue(training_config.get('epochs', 50))
+        self.batch_spin.setValue(training_config.get('batch', 16))
+        self.imgsz_spin.setValue(training_config.get('imgsz', 640))
+        self.device_edit.setText(training_config.get('device') or '')
+        self.val_ratio_spin.setValue(training_config.get('val_ratio', 0.2))
+        self.onnx_out_edit.setText(training_config.get('onnx_out', 'yolov8_finetuned.onnx'))
+        
+        # Set paths
+        self.data_dir_edit.setText(paths_config.get('data_dir', ''))
+    
+    def select_data_directory(self):
+        """Open dialog to select data directory."""
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select Directory with Images and Labels",
+            self.config.get('paths', {}).get('last_image_dir', '')
+        )
+        if directory:
+            self.data_dir_edit.setText(directory)
+            # Update config for future use
+            if 'paths' not in self.config:
+                self.config['paths'] = {}
+            self.config['paths']['last_image_dir'] = directory
+    
+    def validate_inputs(self) -> bool:
+        """Validate user inputs before starting training."""
+        if not self.data_dir_edit.text().strip():
+            QMessageBox.critical(self, "Invalid Input", "Please select a data directory.")
+            return False
+            
+        data_dir = Path(self.data_dir_edit.text())
+        if not data_dir.exists():
+            QMessageBox.critical(self, "Invalid Input", "Selected data directory does not exist.")
+            return False
+            
+        # Check for images and labels
+        image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.gif'}
+        images = [f for f in data_dir.iterdir() if f.suffix.lower() in image_extensions]
+        labels = [f for f in data_dir.iterdir() if f.suffix.lower() == '.txt']
+        
+        if not images:
+            QMessageBox.critical(self, "Invalid Dataset", 
+                               f"No images found in {data_dir}.\nSupported formats: {', '.join(image_extensions)}")
+            return False
+            
+        if not labels:
+            QMessageBox.critical(self, "Invalid Dataset", 
+                               f"No YOLO label files (.txt) found in {data_dir}.")
+            return False
+            
+        return True
+    
+    def start_training(self):
+        """Start the training process."""
+        if not self.validate_inputs():
+            return
+            
+        if self.is_training:
+            QMessageBox.warning(self, "Training in Progress", "Training is already running.")
+            return
+        
+        # Save current configuration
+        self.save_config()
+        
+        # Prepare arguments for train_yolo.py
+        args = [
+            str(Path(self.data_dir_edit.text()).resolve()),
+            '--model', self.model_combo.currentText(),
+            '--epochs', str(self.epochs_spin.value()),
+            '--batch', str(self.batch_spin.value()),
+            '--imgsz', str(self.imgsz_spin.value()),
+            '--val-ratio', str(self.val_ratio_spin.value()),
+            '--onnx-out', self.onnx_out_edit.text()
+        ]
+        
+        if self.device_edit.text().strip():
+            args.extend(['--device', self.device_edit.text().strip()])
+        
+        # Get the train_yolo.py script path
+        train_script = Path(__file__).parent / "train_yolo.py"
+        
+        # Create and start training worker
+        self.training_worker = TrainingWorker(str(train_script), args)
+        self.training_worker.signals.log_updated.connect(self.append_log)
+        self.training_worker.signals.training_finished.connect(self.training_finished)
+        
+        # Update UI for training state
+        self.is_training = True
+        self.start_training_btn.setEnabled(False)
+        self.stop_training_btn.setEnabled(True)
+        self.status_label.setText("Training in progress...")
+        self.progress_bar.setVisible(True)
+        self.progress_bar.setRange(0, 0)  # Indeterminate progress
+        
+        # Clear log and start training
+        self.clear_log()
+        self.append_log("🚀 Starting YOLOv8 training...\n")
+        self.training_worker.start()
+    
+    def stop_training(self):
+        """Stop the training process."""
+        if self.training_worker and self.training_worker.isRunning():
+            self.training_worker.terminate()
+            self.training_worker.wait(3000)  # Wait up to 3 seconds
+            if self.training_worker.isRunning():
+                self.training_worker.kill()  # Force kill if still running
+            
+        self.training_finished(False)
+        self.append_log("\n⏹️ Training stopped by user.\n")
+    
+    def training_finished(self, success: bool):
+        """Handle training completion."""
+        self.is_training = False
+        self.start_training_btn.setEnabled(True)
+        self.stop_training_btn.setEnabled(False)
+        self.progress_bar.setVisible(False)
+        
+        if success:
+            self.status_label.setText("Training completed successfully!")
+        else:
+            self.status_label.setText("Training failed or was interrupted.")
+    
+    def append_log(self, text: str):
+        """Append text to the log display."""
+        cursor = self.log_text.textCursor()
+        cursor.movePosition(QTextCursor.End)
+        cursor.insertText(text)
+        self.log_text.setTextCursor(cursor)
+        self.log_text.ensureCursorVisible()
+    
+    def clear_log(self):
+        """Clear the log display."""
+        self.log_text.clear()
+    
+    def closeEvent(self, event):
+        """Handle application close event."""
+        if self.is_training:
+            reply = QMessageBox.question(
+                self, 'Training in Progress',
+                'Training is currently running. Do you want to stop it and exit?',
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No
+            )
+            
+            if reply == QMessageBox.Yes:
+                self.stop_training()
+                event.accept()
+            else:
+                event.ignore()
+        else:
+            self.save_config()
+            event.accept()
+
+
+def create_app():
+    """Create and return a QApplication instance for headless testing."""
+    return QApplication(sys.argv if sys.argv else [])
+
+
+def main():
+    """Entry point for running the training GUI."""
+    app = create_app()
+    
+    window = TrainYoloGUI()
+    window.show()
+    
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_train_yolo_gui.py
+++ b/tests/test_train_yolo_gui.py
@@ -1,0 +1,240 @@
+"""Tests for the YOLOv8 training GUI (headless)."""
+
+import unittest
+import tempfile
+import yaml
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Import the GUI module
+import sys
+sys.path.append(str(Path(__file__).parent.parent / "pretraining"))
+
+from train_yolo_gui import TrainYoloGUI, create_app
+
+
+class TestTrainYoloGUIHeadless(unittest.TestCase):
+    """Test the non-GUI logic of the training GUI."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.app = create_app()
+        
+        # Create temporary config file
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.config_path = self.temp_dir / "test_config.yaml"
+        
+        # Sample configuration
+        self.sample_config = {
+            'training': {
+                'model': 'yolov8n.pt',
+                'epochs': 10,
+                'batch': 8,
+                'imgsz': 320,
+                'device': 'cpu',
+                'val_ratio': 0.15,
+                'onnx_out': 'test_model.onnx'
+            },
+            'paths': {
+                'data_dir': '/test/data',
+                'last_image_dir': '/test/images',
+                'last_output_dir': '/test/output'
+            }
+        }
+        
+        # Write sample config
+        with open(self.config_path, 'w') as f:
+            yaml.safe_dump(self.sample_config, f)
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        # Clean up temporary files
+        import shutil
+        shutil.rmtree(self.temp_dir)
+    
+    def test_config_loading(self):
+        """Test configuration loading functionality."""
+        # Patch the config path
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Check that configuration was loaded correctly
+            self.assertEqual(gui.config['training']['model'], 'yolov8n.pt')
+            self.assertEqual(gui.config['training']['epochs'], 10)
+            self.assertEqual(gui.config['training']['batch'], 8)
+            self.assertEqual(gui.config['paths']['data_dir'], '/test/data')
+    
+    def test_config_loading_with_missing_file(self):
+        """Test configuration loading when file doesn't exist."""
+        missing_path = self.temp_dir / "missing_config.yaml"
+        
+        with patch.object(TrainYoloGUI, 'config_path', missing_path):
+            gui = TrainYoloGUI()
+            
+            # Check that default configuration is used
+            self.assertEqual(gui.config['training']['model'], 'yolov8x.pt')
+            self.assertEqual(gui.config['training']['epochs'], 50)
+            self.assertEqual(gui.config['training']['batch'], 16)
+    
+    def test_config_saving(self):
+        """Test configuration saving functionality."""
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock UI elements with test values
+            gui.model_combo = MagicMock()
+            gui.model_combo.currentText.return_value = 'yolov8s.pt'
+            
+            gui.epochs_spin = MagicMock()
+            gui.epochs_spin.value.return_value = 25
+            
+            gui.batch_spin = MagicMock()
+            gui.batch_spin.value.return_value = 32
+            
+            gui.imgsz_spin = MagicMock()
+            gui.imgsz_spin.value.return_value = 416
+            
+            gui.device_edit = MagicMock()
+            gui.device_edit.text.return_value = 'cuda'
+            
+            gui.val_ratio_spin = MagicMock()
+            gui.val_ratio_spin.value.return_value = 0.3
+            
+            gui.onnx_out_edit = MagicMock()
+            gui.onnx_out_edit.text.return_value = 'custom_model.onnx'
+            
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = '/custom/data'
+            
+            # Save configuration
+            gui.save_config()
+            
+            # Load and verify saved configuration
+            with open(self.config_path, 'r') as f:
+                saved_config = yaml.safe_load(f)
+            
+            self.assertEqual(saved_config['training']['model'], 'yolov8s.pt')
+            self.assertEqual(saved_config['training']['epochs'], 25)
+            self.assertEqual(saved_config['training']['batch'], 32)
+            self.assertEqual(saved_config['training']['imgsz'], 416)
+            self.assertEqual(saved_config['training']['device'], 'cuda')
+            self.assertEqual(saved_config['training']['val_ratio'], 0.3)
+            self.assertEqual(saved_config['training']['onnx_out'], 'custom_model.onnx')
+            self.assertEqual(saved_config['paths']['data_dir'], '/custom/data')
+    
+    def test_input_validation_missing_directory(self):
+        """Test input validation with missing data directory."""
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock empty data directory
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = ''
+            
+            # Validation should fail
+            self.assertFalse(gui.validate_inputs())
+    
+    def test_input_validation_nonexistent_directory(self):
+        """Test input validation with non-existent data directory."""
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock non-existent data directory
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = '/nonexistent/directory'
+            
+            # Validation should fail
+            self.assertFalse(gui.validate_inputs())
+    
+    def test_input_validation_valid_directory_no_images(self):
+        """Test input validation with directory that has no images."""
+        # Create test directory without images
+        test_data_dir = self.temp_dir / "no_images"
+        test_data_dir.mkdir()
+        
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock data directory path
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = str(test_data_dir)
+            
+            # Validation should fail (no images)
+            self.assertFalse(gui.validate_inputs())
+    
+    def test_input_validation_valid_directory_no_labels(self):
+        """Test input validation with directory that has images but no labels."""
+        # Create test directory with images but no labels
+        test_data_dir = self.temp_dir / "no_labels"
+        test_data_dir.mkdir()
+        
+        # Create a test image
+        (test_data_dir / "test.jpg").touch()
+        
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock data directory path
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = str(test_data_dir)
+            
+            # Validation should fail (no labels)
+            self.assertFalse(gui.validate_inputs())
+    
+    def test_input_validation_valid_directory(self):
+        """Test input validation with valid directory containing images and labels."""
+        # Create test directory with images and labels
+        test_data_dir = self.temp_dir / "valid_data"
+        test_data_dir.mkdir()
+        
+        # Create test files
+        (test_data_dir / "image1.jpg").touch()
+        (test_data_dir / "image1.txt").touch()
+        (test_data_dir / "image2.png").touch()
+        (test_data_dir / "image2.txt").touch()
+        
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock data directory path
+            gui.data_dir_edit = MagicMock()
+            gui.data_dir_edit.text.return_value = str(test_data_dir)
+            
+            # Validation should pass
+            self.assertTrue(gui.validate_inputs())
+    
+    def test_populate_from_config(self):
+        """Test UI population from configuration."""
+        with patch.object(TrainYoloGUI, 'config_path', self.config_path):
+            gui = TrainYoloGUI()
+            
+            # Mock UI elements
+            gui.model_combo = MagicMock()
+            gui.model_combo.itemText = MagicMock(side_effect=['yolov8n.pt', 'yolov8s.pt', 'yolov8m.pt', 'yolov8l.pt', 'yolov8x.pt'])
+            gui.model_combo.count = MagicMock(return_value=5)
+            gui.model_combo.setCurrentText = MagicMock()
+            
+            gui.epochs_spin = MagicMock()
+            gui.batch_spin = MagicMock()
+            gui.imgsz_spin = MagicMock()
+            gui.device_edit = MagicMock()
+            gui.val_ratio_spin = MagicMock()
+            gui.onnx_out_edit = MagicMock()
+            gui.data_dir_edit = MagicMock()
+            
+            # Call populate method
+            gui.populate_from_config()
+            
+            # Verify UI elements were set with config values
+            gui.model_combo.setCurrentText.assert_called_with('yolov8n.pt')
+            gui.epochs_spin.setValue.assert_called_with(10)
+            gui.batch_spin.setValue.assert_called_with(8)
+            gui.imgsz_spin.setValue.assert_called_with(320)
+            gui.device_edit.setText.assert_called_with('cpu')
+            gui.val_ratio_spin.setValue.assert_called_with(0.15)
+            gui.onnx_out_edit.setText.assert_called_with('test_model.onnx')
+            gui.data_dir_edit.setText.assert_called_with('/test/data')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_train_yolo_gui.py
+++ b/tests/test_train_yolo_gui.py
@@ -91,110 +91,99 @@ class TestTrainYoloGUIHeadless(unittest.TestCase):
     
     def test_config_loading(self):
         """Test configuration loading functionality."""
-        # Create a temporary GUI instance and override its config_path
-        with patch('train_yolo_gui.Path') as mock_path:
-            # Make Path(__file__).parent resolve to our temp directory
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            gui.config = gui.load_config()
-            
-            # Check that configuration was loaded correctly
-            self.assertEqual(gui.config['training']['model'], 'yolov8n.pt')
-            self.assertEqual(gui.config['training']['epochs'], 10)
-            self.assertEqual(gui.config['training']['batch'], 8)
-            self.assertEqual(gui.config['paths']['data_dir'], '/test/data')
+        # Create a GUI instance and set its config_path directly
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        gui.config = gui.load_config()
+        
+        # Check that configuration was loaded correctly
+        self.assertEqual(gui.config['training']['model'], 'yolov8n.pt')
+        self.assertEqual(gui.config['training']['epochs'], 10)
+        self.assertEqual(gui.config['training']['batch'], 8)
+        self.assertEqual(gui.config['paths']['data_dir'], '/test/data')
     
     def test_config_loading_with_missing_file(self):
         """Test configuration loading when file doesn't exist."""
         missing_path = self.temp_dir / "missing_config.yaml"
         
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = missing_path
-            gui.config = gui.load_config()
-            
-            # Check that default configuration is used
-            self.assertEqual(gui.config['training']['model'], 'yolov8x.pt')
-            self.assertEqual(gui.config['training']['epochs'], 50)
-            self.assertEqual(gui.config['training']['batch'], 16)
+        gui = TrainYoloGUI()
+        gui.config_path = missing_path
+        gui.config = gui.load_config()
+        
+        # Check that default configuration is used
+        self.assertEqual(gui.config['training']['model'], 'yolov8x.pt')
+        self.assertEqual(gui.config['training']['epochs'], 50)
+        self.assertEqual(gui.config['training']['batch'], 16)
     
     def test_config_saving(self):
         """Test configuration saving functionality."""
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock UI elements with test values
-            gui.model_combo = MagicMock()
-            gui.model_combo.currentText.return_value = 'yolov8s.pt'
-            
-            gui.epochs_spin = MagicMock()
-            gui.epochs_spin.value.return_value = 25
-            
-            gui.batch_spin = MagicMock()
-            gui.batch_spin.value.return_value = 32
-            
-            gui.imgsz_spin = MagicMock()
-            gui.imgsz_spin.value.return_value = 416
-            
-            gui.device_edit = MagicMock()
-            gui.device_edit.text.return_value = 'cuda'
-            
-            gui.val_ratio_spin = MagicMock()
-            gui.val_ratio_spin.value.return_value = 0.3
-            
-            gui.onnx_out_edit = MagicMock()
-            gui.onnx_out_edit.text.return_value = 'custom_model.onnx'
-            
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = '/custom/data'
-            
-            # Save configuration
-            gui.save_config()
-            
-            # Load and verify saved configuration
-            with open(self.config_path, 'r') as f:
-                saved_config = yaml.safe_load(f)
-            
-            self.assertEqual(saved_config['training']['model'], 'yolov8s.pt')
-            self.assertEqual(saved_config['training']['epochs'], 25)
-            self.assertEqual(saved_config['training']['batch'], 32)
-            self.assertEqual(saved_config['training']['imgsz'], 416)
-            self.assertEqual(saved_config['training']['device'], 'cuda')
-            self.assertEqual(saved_config['training']['val_ratio'], 0.3)
-            self.assertEqual(saved_config['training']['onnx_out'], 'custom_model.onnx')
-            self.assertEqual(saved_config['paths']['data_dir'], '/custom/data')
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock UI elements with test values
+        gui.model_combo = MagicMock()
+        gui.model_combo.currentText.return_value = 'yolov8s.pt'
+        
+        gui.epochs_spin = MagicMock()
+        gui.epochs_spin.value.return_value = 25
+        
+        gui.batch_spin = MagicMock()
+        gui.batch_spin.value.return_value = 32
+        
+        gui.imgsz_spin = MagicMock()
+        gui.imgsz_spin.value.return_value = 416
+        
+        gui.device_edit = MagicMock()
+        gui.device_edit.text.return_value = 'cuda'
+        
+        gui.val_ratio_spin = MagicMock()
+        gui.val_ratio_spin.value.return_value = 0.3
+        
+        gui.onnx_out_edit = MagicMock()
+        gui.onnx_out_edit.text.return_value = 'custom_model.onnx'
+        
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = '/custom/data'
+        
+        # Save configuration
+        gui.save_config()
+        
+        # Load and verify saved configuration
+        with open(self.config_path, 'r') as f:
+            saved_config = yaml.safe_load(f)
+        
+        self.assertEqual(saved_config['training']['model'], 'yolov8s.pt')
+        self.assertEqual(saved_config['training']['epochs'], 25)
+        self.assertEqual(saved_config['training']['batch'], 32)
+        self.assertEqual(saved_config['training']['imgsz'], 416)
+        self.assertEqual(saved_config['training']['device'], 'cuda')
+        self.assertEqual(saved_config['training']['val_ratio'], 0.3)
+        self.assertEqual(saved_config['training']['onnx_out'], 'custom_model.onnx')
+        self.assertEqual(saved_config['paths']['data_dir'], '/custom/data')
     
     def test_input_validation_missing_directory(self):
         """Test input validation with missing data directory."""
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock empty data directory
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = ''
-            
-            # Validation should fail
-            self.assertFalse(gui.validate_inputs())
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock empty data directory
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = ''
+        
+        # Validation should fail
+        self.assertFalse(gui.validate_inputs())
     
     def test_input_validation_nonexistent_directory(self):
         """Test input validation with non-existent data directory."""
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock non-existent data directory
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = '/nonexistent/directory'
-            
-            # Validation should fail
-            self.assertFalse(gui.validate_inputs())
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock non-existent data directory
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = '/nonexistent/directory'
+        
+        # Validation should fail
+        self.assertFalse(gui.validate_inputs())
     
     def test_input_validation_valid_directory_no_images(self):
         """Test input validation with directory that has no images."""
@@ -202,17 +191,15 @@ class TestTrainYoloGUIHeadless(unittest.TestCase):
         test_data_dir = self.temp_dir / "no_images"
         test_data_dir.mkdir()
         
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock data directory path
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = str(test_data_dir)
-            
-            # Validation should fail (no images)
-            self.assertFalse(gui.validate_inputs())
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock data directory path
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = str(test_data_dir)
+        
+        # Validation should fail (no images)
+        self.assertFalse(gui.validate_inputs())
     
     def test_input_validation_valid_directory_no_labels(self):
         """Test input validation with directory that has images but no labels."""
@@ -223,17 +210,15 @@ class TestTrainYoloGUIHeadless(unittest.TestCase):
         # Create a test image
         (test_data_dir / "test.jpg").touch()
         
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock data directory path
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = str(test_data_dir)
-            
-            # Validation should fail (no labels)
-            self.assertFalse(gui.validate_inputs())
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock data directory path
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = str(test_data_dir)
+        
+        # Validation should fail (no labels)
+        self.assertFalse(gui.validate_inputs())
     
     def test_input_validation_valid_directory(self):
         """Test input validation with valid directory containing images and labels."""
@@ -247,52 +232,48 @@ class TestTrainYoloGUIHeadless(unittest.TestCase):
         (test_data_dir / "image2.png").touch()
         (test_data_dir / "image2.txt").touch()
         
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            
-            # Mock data directory path
-            gui.data_dir_edit = MagicMock()
-            gui.data_dir_edit.text.return_value = str(test_data_dir)
-            
-            # Validation should pass
-            self.assertTrue(gui.validate_inputs())
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        
+        # Mock data directory path
+        gui.data_dir_edit = MagicMock()
+        gui.data_dir_edit.text.return_value = str(test_data_dir)
+        
+        # Validation should pass
+        self.assertTrue(gui.validate_inputs())
     
     def test_populate_from_config(self):
         """Test UI population from configuration."""
-        with patch('train_yolo_gui.Path') as mock_path:
-            mock_path.return_value.parent = self.temp_dir
-            gui = TrainYoloGUI()
-            gui.config_path = self.config_path
-            gui.config = gui.load_config()
-            
-            # Mock UI elements
-            gui.model_combo = MagicMock()
-            gui.model_combo.itemText = MagicMock(side_effect=['yolov8n.pt', 'yolov8s.pt', 'yolov8m.pt', 'yolov8l.pt', 'yolov8x.pt'])
-            gui.model_combo.count = MagicMock(return_value=5)
-            gui.model_combo.setCurrentText = MagicMock()
-            
-            gui.epochs_spin = MagicMock()
-            gui.batch_spin = MagicMock()
-            gui.imgsz_spin = MagicMock()
-            gui.device_edit = MagicMock()
-            gui.val_ratio_spin = MagicMock()
-            gui.onnx_out_edit = MagicMock()
-            gui.data_dir_edit = MagicMock()
-            
-            # Call populate method
-            gui.populate_from_config()
-            
-            # Verify UI elements were set with config values
-            gui.model_combo.setCurrentText.assert_called_with('yolov8n.pt')
-            gui.epochs_spin.setValue.assert_called_with(10)
-            gui.batch_spin.setValue.assert_called_with(8)
-            gui.imgsz_spin.setValue.assert_called_with(320)
-            gui.device_edit.setText.assert_called_with('cpu')
-            gui.val_ratio_spin.setValue.assert_called_with(0.15)
-            gui.onnx_out_edit.setText.assert_called_with('test_model.onnx')
-            gui.data_dir_edit.setText.assert_called_with('/test/data')
+        gui = TrainYoloGUI()
+        gui.config_path = self.config_path
+        gui.config = gui.load_config()
+        
+        # Mock UI elements
+        gui.model_combo = MagicMock()
+        gui.model_combo.itemText = MagicMock(side_effect=['yolov8n.pt', 'yolov8s.pt', 'yolov8m.pt', 'yolov8l.pt', 'yolov8x.pt'])
+        gui.model_combo.count = MagicMock(return_value=5)
+        gui.model_combo.setCurrentText = MagicMock()
+        
+        gui.epochs_spin = MagicMock()
+        gui.batch_spin = MagicMock()
+        gui.imgsz_spin = MagicMock()
+        gui.device_edit = MagicMock()
+        gui.val_ratio_spin = MagicMock()
+        gui.onnx_out_edit = MagicMock()
+        gui.data_dir_edit = MagicMock()
+        
+        # Call populate method
+        gui.populate_from_config()
+        
+        # Verify UI elements were set with config values
+        gui.model_combo.setCurrentText.assert_called_with('yolov8n.pt')
+        gui.epochs_spin.setValue.assert_called_with(10)
+        gui.batch_spin.setValue.assert_called_with(8)
+        gui.imgsz_spin.setValue.assert_called_with(320)
+        gui.device_edit.setText.assert_called_with('cpu')
+        gui.val_ratio_spin.setValue.assert_called_with(0.15)
+        gui.onnx_out_edit.setText.assert_called_with('test_model.onnx')
+        gui.data_dir_edit.setText.assert_called_with('/test/data')
 
 
 if __name__ == '__main__':

--- a/tests/test_train_yolo_gui.py
+++ b/tests/test_train_yolo_gui.py
@@ -5,11 +5,18 @@ import tempfile
 import yaml
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-# Import the GUI module
 import sys
+
+# Add pretraining directory to path
 sys.path.append(str(Path(__file__).parent.parent / "pretraining"))
 
+# Mock PySide6 for headless testing
+sys.modules['PySide6'] = MagicMock()
+sys.modules['PySide6.QtWidgets'] = MagicMock()
+sys.modules['PySide6.QtCore'] = MagicMock()
+sys.modules['PySide6.QtGui'] = MagicMock()
+
+# Now safely import the GUI module
 from train_yolo_gui import TrainYoloGUI, create_app
 
 
@@ -18,7 +25,8 @@ class TestTrainYoloGUIHeadless(unittest.TestCase):
     
     def setUp(self):
         """Set up test fixtures."""
-        self.app = create_app()
+        # Mock the QApplication for headless testing
+        self.app = MagicMock()
         
         # Create temporary config file
         self.temp_dir = Path(tempfile.mkdtemp())


### PR DESCRIPTION
Implements issue #120: Create PySide6 GUI to run trainyolo.py with custom dataset and config

## Summary
- Created comprehensive training GUI with folder selection, parameter controls, and real-time logging
- Implemented YAML configuration management with persistence
- Added training status indicators and progress tracking
- Created headless tests for non-GUI logic

## Test plan
- [ ] Test GUI launches correctly
- [ ] Test folder selection and validation
- [ ] Test configuration save/load
- [ ] Test training execution with real-time logging
- [ ] Run headless tests: `pytest tests/test_train_yolo_gui.py`

Generated with [Claude Code](https://claude.ai/code)