### PR TITLE
Refactor annotation pipeline: extract config classes and add diagrams

### DIFF
--- a/pretraining/annotation/annotation_config.py
+++ b/pretraining/annotation/annotation_config.py
@@ -1,0 +1,178 @@
+"""Configuration classes for the annotation pipeline."""
+from dataclasses import dataclass, field
+from typing import List, Any
+
+
+@dataclass
+class PipelineStatus:
+    """Keep track of pipeline progress for external observers.
+
+    Purpose
+    -------
+    Expose runtime state so that user interfaces can surface feedback on the
+    pipeline's execution without tightly coupling to internal implementation
+    details.
+
+    Attributes
+    ----------
+    last_function: str
+        Name of the most recently invoked function in this module.
+    current_frame: int
+        Index of the video frame currently being processed (0-based).
+    total_frames: int
+        Total number of frames in the video(s) being processed.
+    processed_frame_count: int
+        Count of frames that have passed quality checks and been processed.
+    """
+
+    last_function: str = ""
+    current_frame: int = 0
+    total_frames: int = 0
+    processed_frame_count: int = 0
+
+
+@dataclass
+class SamplingConfig:
+    """Control how densely frames are sampled from the input videos.
+
+    Purpose
+    -------
+    Describe the temporal down-sampling strategy so that high frame rate
+    inputs do not overwhelm the pipeline.
+
+    Attributes
+    ----------
+    fps: float | None, default ``None``
+        Target frames-per-second rate. If ``None`` the ``step`` parameter is
+        used directly.
+    step: int, default ``1``
+        Fixed stride in frames when ``fps`` is unspecified.
+    min_person_bbox_diagonal_ratio: float, default ``0.001``
+        Smallest allowable ratio between a person's bounding-box diagonal and
+        the image diagonal. Detections below this threshold are discarded to
+        reduce noise from distant subjects.
+    """
+
+    fps: float | None = None
+    step: int = 1
+    min_person_bbox_diagonal_ratio: float = 0.001
+
+
+@dataclass
+class QualityConfig:
+    """Thresholds used to discard blurry or poorly lit frames.
+
+    Purpose
+    -------
+    Avoid exporting frames that are unlikely to yield useful training data by
+    checking focus (blur) and brightness (luma).
+
+    Attributes
+    ----------
+    blur: float, default ``100.0``
+        Minimum Laplacian variance allowed; lower values are considered blurry.
+    luma_min: int, default ``40``
+        Lower bound on the mean pixel intensity.
+    luma_max: int, default ``220``
+        Upper bound on the mean pixel intensity.
+    """
+
+    blur: float = 100.0
+    luma_min: int = 40
+    luma_max: int = 220
+
+
+@dataclass
+class YoloConfig:
+    """Configuration for the YOLO pre-labeling stage.
+
+    Purpose
+    -------
+    Specify model weights and detection sensitivity so the pipeline can
+    bootstrap labels automatically.
+
+    Attributes
+    ----------
+    weights: str
+        Path to the YOLO weights file.
+    conf_thr: float, default ``0.25``
+        Confidence threshold below which detections are ignored.
+    """
+
+    weights: str
+    conf_thr: float = 0.25
+
+
+@dataclass
+class ExportConfig:
+    """Describe how and where annotations should be written.
+
+    Purpose
+    -------
+    Allow the pipeline to output datasets in multiple formats without
+    hard-coding file paths or layout.
+
+    Attributes
+    ----------
+    output_dir: str
+        Destination directory for exported files.
+    format: str, default ``"yolo"``
+        Output style, e.g. ``"yolo"`` or ``"cvat"``.
+    """
+
+    output_dir: str
+    format: str = "yolo"
+
+
+@dataclass
+class TrajectoryConfig:
+    """Settings for smoothing the estimated motion path.
+
+    Purpose
+    -------
+    Allow callers to attenuate high-frequency jitter in the trajectory while
+    preserving temporal alignment via zero-phase filtering.
+
+    Attributes
+    ----------
+    cutoff_hz: float, default ``0.0``
+        Cutoff frequency of the Butterworth low-pass filter in Hertz. A value
+        of ``0.0`` disables filtering.
+    """
+
+    cutoff_hz: float = 0.0
+
+
+@dataclass
+class PipelineConfig:
+    """Aggregate configuration for a pipeline run.
+
+    Purpose
+    -------
+    Bundle all subordinate configuration sections so callers only pass a single
+    object around.
+
+    Attributes
+    ----------
+    videos: list[str]
+        Paths to input videos.
+    sampling: SamplingConfig
+        Controls temporal sampling.
+    quality: QualityConfig
+        Filters out unsuitable frames.
+    yolo: YoloConfig | None
+        Parameters for the pre-labeling model; ``None`` disables detection.
+    export: ExportConfig
+        Dataset export options.
+    detection_gap_timeout_s: float, default ``3.0``
+        Number of seconds without detections after which the current
+        trajectory is finalised and a new track is started.
+    """
+
+    videos: List[str] = field(default_factory=list)
+    sampling: SamplingConfig = field(default_factory=SamplingConfig)
+    quality: QualityConfig = field(default_factory=QualityConfig)
+    yolo: YoloConfig | None = None
+    export: ExportConfig = field(default_factory=lambda: ExportConfig(output_dir="dataset"))
+    trajectory: TrajectoryConfig = field(default_factory=TrajectoryConfig)
+    detection_gap_timeout_s: float = 3.0

--- a/pretraining/annotation/annotation_pipeline.py
+++ b/pretraining/annotation/annotation_pipeline.py
@@ -15,7 +15,7 @@ from functools import wraps
 import logging
 
 # Import configuration classes
-from .annotation_config import (
+from annotation_config import (
     PipelineStatus,
     SamplingConfig, 
     QualityConfig,

--- a/pretraining/annotation/annotation_pipeline.py
+++ b/pretraining/annotation/annotation_pipeline.py
@@ -1,5 +1,4 @@
 """Annotation dataset pipeline for video ingestion and labeling."""
-from dataclasses import dataclass, field
 import json
 from pathlib import Path
 from typing import Iterator, List, Dict, Any, Callable
@@ -15,6 +14,17 @@ import sys
 from functools import wraps
 import logging
 
+# Import configuration classes
+from .annotation_config import (
+    PipelineStatus,
+    SamplingConfig, 
+    QualityConfig,
+    YoloConfig,
+    ExportConfig,
+    TrajectoryConfig,
+    PipelineConfig,
+)
+
 # Import DnnHandler for optional ONNX inference
 MODULE_DIR = Path(__file__).resolve().parents[2] / "code" / "modules"
 if str(MODULE_DIR) not in sys.path:
@@ -26,34 +36,6 @@ except Exception:  # pragma: no cover - DnnHandler might not be available
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class PipelineStatus:
-    """Keep track of pipeline progress for external observers.
-
-    Purpose
-    -------
-    Expose runtime state so that user interfaces can surface feedback on the
-    pipeline's execution without tightly coupling to internal implementation
-    details.
-
-    Attributes
-    ----------
-    last_function: str
-        Name of the most recently invoked function in this module.
-    current_frame: int
-        Index of the video frame currently being processed (0-based).
-    total_frames: int
-        Total number of frames in the video(s) being processed.
-    processed_frame_count: int
-        Count of frames that have passed quality checks and been processed.
-    """
-
-    last_function: str = ""
-    current_frame: int = 0
-    total_frames: int = 0
-    processed_frame_count: int = 0
 
 
 status = PipelineStatus()
@@ -92,147 +74,6 @@ def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
-
-@dataclass
-class SamplingConfig:
-    """Control how densely frames are sampled from the input videos.
-
-    Purpose
-    -------
-    Describe the temporal down-sampling strategy so that high frame rate
-    inputs do not overwhelm the pipeline.
-
-    Attributes
-    ----------
-    fps: float | None, default ``None``
-        Target frames-per-second rate. If ``None`` the ``step`` parameter is
-        used directly.
-    step: int, default ``1``
-        Fixed stride in frames when ``fps`` is unspecified.
-    min_person_bbox_diagonal_ratio: float, default ``0.001``
-        Smallest allowable ratio between a person's bounding-box diagonal and
-        the image diagonal. Detections below this threshold are discarded to
-        reduce noise from distant subjects.
-    """
-
-    fps: float | None = None
-    step: int = 1
-    min_person_bbox_diagonal_ratio: float = 0.001
-
-@dataclass
-class QualityConfig:
-    """Thresholds used to discard blurry or poorly lit frames.
-
-    Purpose
-    -------
-    Avoid exporting frames that are unlikely to yield useful training data by
-    checking focus (blur) and brightness (luma).
-
-    Attributes
-    ----------
-    blur: float, default ``100.0``
-        Minimum Laplacian variance allowed; lower values are considered blurry.
-    luma_min: int, default ``40``
-        Lower bound on the mean pixel intensity.
-    luma_max: int, default ``220``
-        Upper bound on the mean pixel intensity.
-    """
-
-    blur: float = 100.0
-    luma_min: int = 40
-    luma_max: int = 220
-
-@dataclass
-class YoloConfig:
-    """Configuration for the YOLO pre-labeling stage.
-
-    Purpose
-    -------
-    Specify model weights and detection sensitivity so the pipeline can
-    bootstrap labels automatically.
-
-    Attributes
-    ----------
-    weights: str
-        Path to the YOLO weights file.
-    conf_thr: float, default ``0.25``
-        Confidence threshold below which detections are ignored.
-    """
-
-    weights: str
-    conf_thr: float = 0.25
-
-@dataclass
-class ExportConfig:
-    """Describe how and where annotations should be written.
-
-    Purpose
-    -------
-    Allow the pipeline to output datasets in multiple formats without
-    hard-coding file paths or layout.
-
-    Attributes
-    ----------
-    output_dir: str
-        Destination directory for exported files.
-    format: str, default ``"yolo"``
-        Output style, e.g. ``"yolo"`` or ``"cvat"``.
-    """
-
-    output_dir: str
-    format: str = "yolo"
-
-@dataclass
-class TrajectoryConfig:
-    """Settings for smoothing the estimated motion path.
-
-    Purpose
-    -------
-    Allow callers to attenuate high-frequency jitter in the trajectory while
-    preserving temporal alignment via zero-phase filtering.
-
-    Attributes
-    ----------
-    cutoff_hz: float, default ``0.0``
-        Cutoff frequency of the Butterworth low-pass filter in Hertz. A value
-        of ``0.0`` disables filtering.
-    """
-
-    cutoff_hz: float = 0.0
-
-@dataclass
-class PipelineConfig:
-    """Aggregate configuration for a pipeline run.
-
-    Purpose
-    -------
-    Bundle all subordinate configuration sections so callers only pass a single
-    object around.
-
-    Attributes
-    ----------
-    videos: list[str]
-        Paths to input videos.
-    sampling: SamplingConfig
-        Controls temporal sampling.
-    quality: QualityConfig
-        Filters out unsuitable frames.
-    yolo: YoloConfig | None
-        Parameters for the pre-labeling model; ``None`` disables detection.
-    export: ExportConfig
-        Dataset export options.
-    detection_gap_timeout_s: float, default ``3.0``
-        Number of seconds without detections after which the current
-        trajectory is finalised and a new track is started.
-    """
-
-    videos: List[str] = field(default_factory=list)
-    sampling: SamplingConfig = field(default_factory=SamplingConfig)
-    quality: QualityConfig = field(default_factory=QualityConfig)
-    yolo: YoloConfig | None = None
-    export: ExportConfig = field(default_factory=lambda: ExportConfig(output_dir="dataset"))
-    trajectory: TrajectoryConfig = field(default_factory=TrajectoryConfig)
-    detection_gap_timeout_s: float = 3.0
 
 
 class VidIngest:

--- a/pretraining/annotation/caller_diagram.md
+++ b/pretraining/annotation/caller_diagram.md
@@ -1,0 +1,119 @@
+# Annotation Pipeline Caller Diagram
+
+This diagram shows the calling relationships between classes and functions in the annotation pipeline.
+
+## Main Entry Points
+
+```
+main() ────┐
+           ├── run()
+           └── preview()
+```
+
+## Core Pipeline Flow (run() function)
+
+```
+run()
+├── _ensure_cfg() ────── load_config()
+├── VidIngest()
+├── QualityFilter()
+├── PreLabelYOLO()
+├── DatasetExporter() OR CvatExporter()
+├── [Frame Processing Loop]
+│   ├── VidIngest.__iter__()
+│   ├── QualityFilter.check()
+│   ├── PreLabelYOLO.detect()
+│   └── filter_small_person_boxes()
+├── [Trajectory Segmentation]
+├── _export_segment() [for each segment]
+│   ├── CubicSpline() [scipy]
+│   ├── _lowpass_filter()
+│   │   └── butter(), filtfilt() [scipy.signal]
+│   ├── DatasetExporter.save() OR CvatExporter.save()
+│   └── _save_trajectory_image() [if gui_mode]
+└── exporter.close()
+```
+
+## Preview Flow
+
+```
+preview()
+├── _ensure_cfg() ────── load_config()
+├── VidIngest()
+├── QualityFilter()
+├── PreLabelYOLO()
+└── [Frame Processing Loop]
+    ├── VidIngest.__iter__()
+    ├── QualityFilter.check()
+    ├── PreLabelYOLO.detect()
+    └── filter_small_person_boxes()
+```
+
+## Class Dependencies
+
+```
+VidIngest
+├── Uses: SamplingConfig
+└── Calls: cv2.VideoCapture()
+
+QualityFilter
+├── Uses: QualityConfig
+└── Calls: cv2.cvtColor(), cv2.Laplacian()
+
+PreLabelYOLO
+├── Uses: YoloConfig
+├── Optionally uses: DnnHandler (if ONNX)
+├── Optionally uses: YOLO (Ultralytics)
+└── Calls: model inference methods
+
+DatasetExporter
+├── Uses: ExportConfig
+└── Calls: cv2.imwrite(), json.dumps()
+
+CvatExporter  
+├── Uses: ExportConfig
+└── Calls: cv2.imwrite(), xml.etree.ElementTree
+```
+
+## Utility Functions
+
+```
+track() ────── [decorator for status tracking]
+           └── Updates: PipelineStatus
+
+_ensure_cfg() ────── load_config()
+              └── Creates config objects from dict
+
+filter_small_person_boxes() ────── np.hypot()
+
+_lowpass_filter() ────── butter(), filtfilt()
+
+_save_trajectory_image() ────── cv2.polylines(), cv2.rectangle(), cv2.imwrite()
+```
+
+## Configuration Classes (in annotation_config.py)
+
+```
+PipelineConfig
+├── Contains: SamplingConfig
+├── Contains: QualityConfig  
+├── Contains: YoloConfig
+├── Contains: ExportConfig
+├── Contains: TrajectoryConfig
+└── Contains: detection_gap_timeout_s
+
+PipelineStatus ────── [Global status instance]
+```
+
+## External Dependencies
+
+```
+OpenCV (cv2) ────── Video processing, image operations
+scipy ────── CubicSpline, butter, filtfilt
+ultralytics ────── YOLO model
+yaml ────── Configuration loading
+numpy ────── Array operations
+pathlib ────── File path operations
+json ────── Debug logging
+xml.etree.ElementTree ────── CVAT export format
+```

--- a/pretraining/annotation/flow_diagram.md
+++ b/pretraining/annotation/flow_diagram.md
@@ -1,0 +1,231 @@
+# Annotation Pipeline Flow Diagram
+
+This diagram shows the data flow and processing stages in the annotation pipeline.
+
+## High-Level Pipeline Flow
+
+```
+[Input Videos] ──► [Configuration] ──► [Pipeline Processing] ──► [Output Dataset]
+                                              │
+                                              ▼
+                                      [Optional Preview]
+```
+
+## Detailed Processing Flow
+
+```
+┌─────────────────┐
+│  Input Videos   │
+│  + Config YAML  │
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│   load_config() │ ──► Create PipelineConfig object
+│   _ensure_cfg()  │     with all sub-configs
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Initialize     │
+│  Components:    │
+│  • VidIngest    │
+│  • QualityFilter│
+│  • PreLabelYOLO │
+│  • Exporter     │
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Frame Ingestion│ ──► For each video:
+│  Loop           │     • Open with cv2.VideoCapture
+│                 │     • Calculate sampling step
+│                 │     • Yield frames at target FPS
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Quality Check  │ ──► For each frame:
+│                 │     • Convert to grayscale  
+│                 │     • Check blur (Laplacian variance)
+│                 │     • Check luma (brightness)
+│                 │     • Filter out poor quality frames
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  YOLO Detection │ ──► Run inference:
+│                 │     • DnnHandler (ONNX) OR Ultralytics
+│                 │     • Extract person bounding boxes
+│                 │     • Apply confidence threshold
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Box Filtering  │ ──► Remove tiny detections:
+│                 │     • Calculate bbox diagonal
+│                 │     • Compare to image diagonal
+│                 │     • Filter by min ratio threshold
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Collect Items  │ ──► Accumulate processed frames
+│                 │     with detections for trajectory
+│                 │     generation
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Trajectory     │ ──► Group detections into segments:
+│  Segmentation   │     • Detect gaps > timeout
+│                 │     • Split into separate tracks
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  For Each       │
+│  Trajectory     │
+│  Segment:       │
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Interpolation  │ ──► If >= 2 detection points:
+│                 │     • Create CubicSpline for x,y,w,h
+│                 │     • Interpolate between keyframes
+│                 │     • Fill missing detections
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Smoothing      │ ──► Apply low-pass filter:
+│  (Optional)     │     • Butterworth filter
+│                 │     • Zero-phase (filtfilt)
+│                 │     • Configurable cutoff frequency
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Export         │ ──► Save to disk:
+│                 │     • Images (.jpg)
+│                 │     • Labels (YOLO .txt OR CVAT .xml)
+│                 │     • Debug log (.jsonl)
+│                 │     • Trajectory images (GUI mode)
+└─────────┬───────┘
+          │
+          ▼
+┌─────────────────┐
+│  Final Output   │
+│                 │
+│  YOLO Format:   │     CVAT Format:
+│  • images/      │     • images/
+│  • labels/      │     • annotations.xml
+│  • debug.jsonl  │
+│  • trajectories/│
+│    (GUI mode)   │
+└─────────────────┘
+```
+
+## Data Structures Flow
+
+```
+Raw Video Frames
+        │
+        ▼
+Frame Dictionary: {
+    "video": path,
+    "frame_idx": int,
+    "frame": ndarray
+}
+        │
+        ▼
+Quality Filtered Frames
+        │
+        ▼  
+Frames with Detection Boxes: {
+    ...,
+    "boxes": [bbox_dict, ...],
+    "discarded_boxes": [small_bbox, ...] (optional)
+}
+        │
+        ▼
+Detection Points List: [
+    (frame_idx, cx, cy, w, h, cls, label),
+    ...
+]
+        │
+        ▼
+Trajectory Segments: [
+    [det_point1, det_point2, ...],
+    [det_point3, det_point4, ...],
+    ...
+]
+        │
+        ▼
+Interpolated Trajectories: [
+    (frame_idx, cx, cy, w, h, conf, frame_dict),
+    ...
+]
+        │
+        ▼
+Smoothed Coordinates: [x_smooth], [y_smooth]
+        │
+        ▼
+Final Bounding Boxes with Track IDs
+        │
+        ▼
+Exported Dataset Files
+```
+
+## Configuration Flow
+
+```
+YAML Config File
+        │
+        ▼
+Dict[str, Any]
+        │
+        ▼
+PipelineConfig {
+    videos: List[str],
+    sampling: SamplingConfig,
+    quality: QualityConfig, 
+    yolo: YoloConfig,
+    export: ExportConfig,
+    trajectory: TrajectoryConfig,
+    detection_gap_timeout_s: float
+}
+        │
+        ▼
+Individual Config Objects used by:
+• SamplingConfig ──► VidIngest
+• QualityConfig ──► QualityFilter  
+• YoloConfig ──► PreLabelYOLO
+• ExportConfig ──► DatasetExporter/CvatExporter
+• TrajectoryConfig ──► _lowpass_filter()
+```
+
+## Preview Mode Flow (Simplified)
+
+```
+[Input Videos] ──► [Frame Ingestion] ──► [Quality Check] ──► [YOLO Detection] ──► [Real-time Display]
+                                                                                          │
+                                                                                          ▼
+                                                                                  [OpenCV Window]
+                                                                                  [User presses 'q' to quit]
+```
+
+## Status Tracking Flow
+
+```
+@track decorator ──► Updates PipelineStatus {
+    last_function: str,
+    current_frame: int, 
+    total_frames: int,
+    processed_frame_count: int
+}
+        │
+        ▼
+Available for GUI/external monitoring
+```


### PR DESCRIPTION
Addresses #126

## Changes
- Extract 7 configuration dataclasses to annotation_config.py
- Reduce main annotation_pipeline.py from 1224 to 1064 lines
- Add comprehensive caller and flow diagrams
- Update imports for cleaner code organization

Generated with [Claude Code](https://claude.ai/code)