### PR TITLE
Add PySide6 GUI for YOLO model training

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ python code/Application/edge_main.py
 
 # Test runner for core functionality
 python test/run_test.py
+
+# YOLO training GUI for fine-tuning models
+python run_train_gui.py
 ```
 
 ### Testing

--- a/pretraining/train_yolo_gui.py
+++ b/pretraining/train_yolo_gui.py
@@ -1,0 +1,346 @@
+"""PySide6-based GUI for YOLO model training."""
+
+import threading
+import sys
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QLabel, QLineEdit, QPushButton, QFrame, QFileDialog, QMessageBox,
+    QSpinBox, QDoubleSpinBox, QComboBox, QTextEdit, QScrollArea
+)
+from PySide6.QtCore import Qt, QTimer, Signal, QObject
+from PySide6.QtGui import QFont
+
+
+class TrainingSignals(QObject):
+    """Signals for thread-safe training updates."""
+    output_ready = Signal(str)
+    training_finished = Signal(bool, str)  # success, message
+
+
+class TrainYoloGUI(QMainWindow):
+    """PySide6 GUI for YOLO model training."""
+
+    def __init__(self):
+        """Create widgets and bind actions."""
+        super().__init__()
+        self.setWindowTitle("YOLO Model Training")
+        self.setGeometry(100, 100, 800, 600)
+        
+        # Initialize variables
+        self.data_dir = ""
+        self.training_process = None
+        self.is_training = False
+        
+        # Central widget and main layout
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+        main_layout = QVBoxLayout(central_widget)
+        
+        # Title
+        title_label = QLabel("YOLO Model Training")
+        title_font = QFont()
+        title_font.setPointSize(16)
+        title_font.setBold(True)
+        title_label.setFont(title_font)
+        title_label.setAlignment(Qt.AlignCenter)
+        main_layout.addWidget(title_label)
+        
+        # Data directory selection
+        data_section = QFrame()
+        data_section.setFrameStyle(QFrame.Box)
+        data_layout = QVBoxLayout(data_section)
+        
+        data_title = QLabel("Dataset Configuration")
+        data_title.setFont(QFont("", 12, QFont.Bold))
+        data_layout.addWidget(data_title)
+        
+        # Data directory selection
+        data_dir_layout = QHBoxLayout()
+        data_dir_layout.addWidget(QLabel("Images & Annotations Directory:"))
+        self.select_data_btn = QPushButton("Select Directory")
+        self.select_data_btn.clicked.connect(self.select_data_directory)
+        data_dir_layout.addWidget(self.select_data_btn)
+        data_layout.addLayout(data_dir_layout)
+        
+        self.data_dir_label = QLabel("No directory selected")
+        self.data_dir_label.setWordWrap(True)
+        self.data_dir_label.setStyleSheet("color: gray; font-style: italic;")
+        data_layout.addWidget(self.data_dir_label)
+        
+        main_layout.addWidget(data_section)
+        
+        # Training parameters
+        params_section = QFrame()
+        params_section.setFrameStyle(QFrame.Box)
+        params_layout = QVBoxLayout(params_section)
+        
+        params_title = QLabel("Training Parameters")
+        params_title.setFont(QFont("", 12, QFont.Bold))
+        params_layout.addWidget(params_title)
+        
+        # Model selection
+        model_layout = QHBoxLayout()
+        model_layout.addWidget(QLabel("Base Model:"))
+        self.model_combo = QComboBox()
+        self.model_combo.addItems(["yolov8n.pt", "yolov8s.pt", "yolov8m.pt", "yolov8l.pt", "yolov8x.pt"])
+        self.model_combo.setCurrentText("yolov8x.pt")
+        model_layout.addWidget(self.model_combo)
+        model_layout.addStretch()
+        params_layout.addLayout(model_layout)
+        
+        # Epochs
+        epochs_layout = QHBoxLayout()
+        epochs_layout.addWidget(QLabel("Epochs:"))
+        self.epochs_spin = QSpinBox()
+        self.epochs_spin.setMinimum(1)
+        self.epochs_spin.setMaximum(1000)
+        self.epochs_spin.setValue(50)
+        epochs_layout.addWidget(self.epochs_spin)
+        epochs_layout.addStretch()
+        params_layout.addLayout(epochs_layout)
+        
+        # Batch size
+        batch_layout = QHBoxLayout()
+        batch_layout.addWidget(QLabel("Batch Size:"))
+        self.batch_spin = QSpinBox()
+        self.batch_spin.setMinimum(1)
+        self.batch_spin.setMaximum(128)
+        self.batch_spin.setValue(16)
+        batch_layout.addWidget(self.batch_spin)
+        batch_layout.addStretch()
+        params_layout.addLayout(batch_layout)
+        
+        # Image size
+        imgsz_layout = QHBoxLayout()
+        imgsz_layout.addWidget(QLabel("Image Size:"))
+        self.imgsz_spin = QSpinBox()
+        self.imgsz_spin.setMinimum(32)
+        self.imgsz_spin.setMaximum(1024)
+        self.imgsz_spin.setValue(640)
+        self.imgsz_spin.setSingleStep(32)
+        imgsz_layout.addWidget(self.imgsz_spin)
+        imgsz_layout.addStretch()
+        params_layout.addLayout(imgsz_layout)
+        
+        # Validation ratio
+        val_layout = QHBoxLayout()
+        val_layout.addWidget(QLabel("Validation Ratio:"))
+        self.val_ratio_spin = QDoubleSpinBox()
+        self.val_ratio_spin.setMinimum(0.05)
+        self.val_ratio_spin.setMaximum(0.5)
+        self.val_ratio_spin.setValue(0.2)
+        self.val_ratio_spin.setSingleStep(0.05)
+        val_layout.addWidget(self.val_ratio_spin)
+        val_layout.addStretch()
+        params_layout.addLayout(val_layout)
+        
+        # Device selection
+        device_layout = QHBoxLayout()
+        device_layout.addWidget(QLabel("Device:"))
+        self.device_combo = QComboBox()
+        self.device_combo.addItems(["auto", "cpu", "0", "1"])
+        device_layout.addWidget(self.device_combo)
+        device_layout.addStretch()
+        params_layout.addLayout(device_layout)
+        
+        # Output ONNX path
+        onnx_layout = QHBoxLayout()
+        onnx_layout.addWidget(QLabel("Output ONNX Name:"))
+        self.onnx_edit = QLineEdit("yolov8_finetuned.onnx")
+        onnx_layout.addWidget(self.onnx_edit)
+        params_layout.addLayout(onnx_layout)
+        
+        main_layout.addWidget(params_section)
+        
+        # Control buttons
+        controls_layout = QHBoxLayout()
+        self.start_btn = QPushButton("Start Training")
+        self.start_btn.clicked.connect(self.start_training)
+        self.start_btn.setStyleSheet("QPushButton { background-color: #4CAF50; color: white; font-weight: bold; }")
+        controls_layout.addWidget(self.start_btn)
+        
+        self.stop_btn = QPushButton("Stop Training")
+        self.stop_btn.clicked.connect(self.stop_training)
+        self.stop_btn.setEnabled(False)
+        self.stop_btn.setStyleSheet("QPushButton { background-color: #f44336; color: white; font-weight: bold; }")
+        controls_layout.addWidget(self.stop_btn)
+        
+        controls_layout.addStretch()
+        main_layout.addLayout(controls_layout)
+        
+        # Status
+        self.status_label = QLabel("Ready to start training")
+        self.status_label.setAlignment(Qt.AlignCenter)
+        main_layout.addWidget(self.status_label)
+        
+        # Output log
+        log_label = QLabel("Training Output:")
+        log_label.setFont(QFont("", 10, QFont.Bold))
+        main_layout.addWidget(log_label)
+        
+        self.output_text = QTextEdit()
+        self.output_text.setMaximumHeight(200)
+        self.output_text.setFont(QFont("Consolas", 9))
+        main_layout.addWidget(self.output_text)
+        
+        # Set up signals for thread-safe updates
+        self.training_signals = TrainingSignals()
+        self.training_signals.output_ready.connect(self._update_output)
+        self.training_signals.training_finished.connect(self._training_finished)
+
+    def select_data_directory(self) -> None:
+        """Prompt the user to select a directory containing images and annotations."""
+        directory = QFileDialog.getExistingDirectory(
+            self,
+            "Select directory containing images and YOLO .txt annotations"
+        )
+        if directory:
+            self.data_dir = directory
+            self.data_dir_label.setText(directory)
+            self.data_dir_label.setStyleSheet("color: black;")
+
+    def start_training(self) -> None:
+        """Launch training in a background thread."""
+        if not self.data_dir:
+            QMessageBox.critical(
+                self,
+                "Missing Data Directory",
+                "Please select a directory containing images and annotations"
+            )
+            return
+            
+        # Validate data directory contains images and labels
+        data_path = Path(self.data_dir)
+        image_files = list(data_path.glob("*.jpg")) + list(data_path.glob("*.png"))
+        label_files = list(data_path.glob("*.txt"))
+        
+        if not image_files:
+            QMessageBox.critical(
+                self,
+                "No Images Found",
+                "The selected directory doesn't contain any .jpg or .png image files"
+            )
+            return
+            
+        if not label_files:
+            QMessageBox.critical(
+                self,
+                "No Labels Found", 
+                "The selected directory doesn't contain any .txt annotation files"
+            )
+            return
+        
+        # Update UI state
+        self.is_training = True
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+        self.status_label.setText("Training in progress...")
+        self.output_text.clear()
+        
+        # Start training in background thread
+        thread = threading.Thread(
+            target=self._run_training_thread,
+            daemon=True
+        )
+        thread.start()
+
+    def _run_training_thread(self) -> None:
+        """Execute training and emit signals for UI updates."""
+        try:
+            # Build command
+            train_script = Path(__file__).parent / "train_yolo.py"
+            cmd = [
+                sys.executable, str(train_script),
+                self.data_dir,
+                "--model", self.model_combo.currentText(),
+                "--epochs", str(self.epochs_spin.value()),
+                "--batch", str(self.batch_spin.value()),
+                "--imgsz", str(self.imgsz_spin.value()),
+                "--val-ratio", str(self.val_ratio_spin.value()),
+                "--onnx-out", self.onnx_edit.text()
+            ]
+            
+            # Add device if not auto
+            if self.device_combo.currentText() != "auto":
+                cmd.extend(["--device", self.device_combo.currentText()])
+            
+            # Run training process
+            self.training_process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                bufsize=1
+            )
+            
+            # Stream output
+            for line in self.training_process.stdout:
+                if not self.is_training:  # Check if stopped
+                    break
+                self.training_signals.output_ready.emit(line.rstrip())
+            
+            # Wait for completion
+            return_code = self.training_process.wait()
+            
+            if return_code == 0:
+                self.training_signals.training_finished.emit(True, "Training completed successfully!")
+            else:
+                self.training_signals.training_finished.emit(False, f"Training failed with exit code {return_code}")
+                
+        except Exception as e:
+            self.training_signals.training_finished.emit(False, f"Training error: {str(e)}")
+
+    def stop_training(self) -> None:
+        """Stop the current training process."""
+        if self.training_process and self.training_process.poll() is None:
+            self.training_process.terminate()
+        
+        self.is_training = False
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+        self.status_label.setText("Training stopped by user")
+
+    def _update_output(self, line: str) -> None:
+        """Update the output text area with new training output."""
+        self.output_text.append(line)
+        # Auto-scroll to bottom
+        scrollbar = self.output_text.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
+
+    def _training_finished(self, success: bool, message: str) -> None:
+        """Handle training completion."""
+        self.is_training = False
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+        self.status_label.setText(message)
+        
+        if success:
+            QMessageBox.information(self, "Training Complete", message)
+        else:
+            QMessageBox.critical(self, "Training Failed", message)
+
+
+def create_app():
+    """Create and return a QApplication instance for headless testing."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv if sys.argv else [])
+    return app
+
+
+def main():
+    """Entry point for running the training GUI."""
+    app = create_app()
+    
+    window = TrainYoloGUI()
+    window.show()
+    
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-oauthlib
 open_gopro
 boxsdk
 PySide6
+pytest-qt

--- a/run_train_gui.py
+++ b/run_train_gui.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Launcher script for the YOLO training GUI."""
+
+import sys
+from pathlib import Path
+
+# Add pretraining directory to path so we can import the GUI
+sys.path.insert(0, str(Path(__file__).parent / "pretraining"))
+
+from train_yolo_gui import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_train_yolo_gui.py
+++ b/tests/test_train_yolo_gui.py
@@ -1,0 +1,232 @@
+"""Tests for the YOLO training GUI."""
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "pretraining"))
+from train_yolo_gui import TrainYoloGUI, create_app
+
+
+class TestTrainYoloGUI:
+    """Test cases for the YOLO training GUI."""
+
+    @pytest.fixture(autouse=True)
+    def setup_app(self):
+        """Set up QApplication for GUI testing."""
+        self.app = create_app()
+        yield
+        # Clean up after each test
+        if self.app:
+            self.app.processEvents()
+
+    @pytest.fixture
+    def gui(self):
+        """Create a TrainYoloGUI instance for testing."""
+        return TrainYoloGUI()
+
+    @pytest.fixture
+    def temp_data_dir(self):
+        """Create a temporary directory with sample images and labels."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create sample image files
+            for i in range(3):
+                (temp_path / f"image_{i}.jpg").write_text("fake image data")
+                
+            # Create sample label files
+            for i in range(3):
+                (temp_path / f"image_{i}.txt").write_text("0 0.5 0.5 0.1 0.1")
+                
+            yield temp_path
+
+    def test_gui_creation(self, gui):
+        """Test that the GUI can be created without errors."""
+        assert gui.windowTitle() == "YOLO Model Training"
+        assert gui.data_dir == ""
+        assert not gui.is_training
+
+    def test_initial_ui_state(self, gui):
+        """Test the initial state of UI components."""
+        assert gui.start_btn.isEnabled()
+        assert not gui.stop_btn.isEnabled()
+        assert gui.status_label.text() == "Ready to start training"
+        assert gui.model_combo.currentText() == "yolov8x.pt"
+        assert gui.epochs_spin.value() == 50
+        assert gui.batch_spin.value() == 16
+
+    def test_select_data_directory(self, gui, temp_data_dir):
+        """Test data directory selection functionality."""
+        # Simulate selecting a directory
+        gui.data_dir = str(temp_data_dir)
+        gui.data_dir_label.setText(str(temp_data_dir))
+        
+        assert gui.data_dir == str(temp_data_dir)
+        assert gui.data_dir_label.text() == str(temp_data_dir)
+
+    def test_validation_no_data_directory(self, gui, qtbot):
+        """Test validation when no data directory is selected."""
+        with patch('PySide6.QtWidgets.QMessageBox.critical') as mock_critical:
+            gui.start_training()
+            mock_critical.assert_called_once()
+            
+        # Button should remain enabled since training didn't start
+        assert gui.start_btn.isEnabled()
+        assert not gui.stop_btn.isEnabled()
+
+    def test_validation_no_images(self, gui, qtbot):
+        """Test validation when directory has no images."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Directory with no files
+            gui.data_dir = temp_dir
+            
+            with patch('PySide6.QtWidgets.QMessageBox.critical') as mock_critical:
+                gui.start_training()
+                mock_critical.assert_called_once()
+                
+            assert gui.start_btn.isEnabled()
+
+    def test_validation_no_labels(self, gui, qtbot):
+        """Test validation when directory has images but no labels."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            # Create only image files, no labels
+            (temp_path / "image.jpg").write_text("fake image data")
+            
+            gui.data_dir = temp_dir
+            
+            with patch('PySide6.QtWidgets.QMessageBox.critical') as mock_critical:
+                gui.start_training()
+                mock_critical.assert_called_once()
+                
+            assert gui.start_btn.isEnabled()
+
+    def test_parameter_configuration(self, gui):
+        """Test that training parameters can be configured."""
+        # Test model selection
+        gui.model_combo.setCurrentText("yolov8n.pt")
+        assert gui.model_combo.currentText() == "yolov8n.pt"
+        
+        # Test epochs
+        gui.epochs_spin.setValue(100)
+        assert gui.epochs_spin.value() == 100
+        
+        # Test batch size
+        gui.batch_spin.setValue(8)
+        assert gui.batch_spin.value() == 8
+        
+        # Test image size
+        gui.imgsz_spin.setValue(512)
+        assert gui.imgsz_spin.value() == 512
+        
+        # Test validation ratio
+        gui.val_ratio_spin.setValue(0.3)
+        assert gui.val_ratio_spin.value() == 0.3
+        
+        # Test device
+        gui.device_combo.setCurrentText("cpu")
+        assert gui.device_combo.currentText() == "cpu"
+        
+        # Test output name
+        gui.onnx_edit.setText("custom_model.onnx")
+        assert gui.onnx_edit.text() == "custom_model.onnx"
+
+    @patch('pretraining.train_yolo_gui.subprocess.Popen')
+    @patch('threading.Thread')
+    def test_start_training_valid_data(self, mock_thread, mock_popen, gui, temp_data_dir):
+        """Test starting training with valid data directory."""
+        gui.data_dir = str(temp_data_dir)
+        
+        # Mock successful process
+        mock_process = MagicMock()
+        mock_process.stdout = ["Training line 1", "Training line 2"]
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+        
+        gui.start_training()
+        
+        # Verify UI state changes
+        assert not gui.start_btn.isEnabled()
+        assert gui.stop_btn.isEnabled()
+        assert gui.is_training
+        assert "Training in progress" in gui.status_label.text()
+        
+        # Verify thread was started
+        mock_thread.assert_called_once()
+
+    def test_stop_training(self, gui):
+        """Test stopping training functionality."""
+        # Simulate training state
+        gui.is_training = True
+        gui.start_btn.setEnabled(False)
+        gui.stop_btn.setEnabled(True)
+        
+        # Mock process
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None  # Process still running
+        gui.training_process = mock_process
+        
+        gui.stop_training()
+        
+        # Verify process termination
+        mock_process.terminate.assert_called_once()
+        
+        # Verify UI state reset
+        assert not gui.is_training
+        assert gui.start_btn.isEnabled()
+        assert not gui.stop_btn.isEnabled()
+        assert "stopped" in gui.status_label.text().lower()
+
+    def test_output_update(self, gui):
+        """Test training output update functionality."""
+        initial_text = gui.output_text.toPlainText()
+        
+        gui._update_output("Test training output line")
+        
+        updated_text = gui.output_text.toPlainText()
+        assert "Test training output line" in updated_text
+        assert len(updated_text) > len(initial_text)
+
+    def test_training_finished_success(self, gui):
+        """Test successful training completion handling."""
+        gui.is_training = True
+        gui.start_btn.setEnabled(False)
+        gui.stop_btn.setEnabled(True)
+        
+        with patch('PySide6.QtWidgets.QMessageBox.information') as mock_info:
+            gui._training_finished(True, "Training completed successfully!")
+            mock_info.assert_called_once()
+        
+        # Verify UI state reset
+        assert not gui.is_training
+        assert gui.start_btn.isEnabled()
+        assert not gui.stop_btn.isEnabled()
+        assert "successfully" in gui.status_label.text()
+
+    def test_training_finished_failure(self, gui):
+        """Test failed training completion handling."""
+        gui.is_training = True
+        gui.start_btn.setEnabled(False)
+        gui.stop_btn.setEnabled(True)
+        
+        with patch('PySide6.QtWidgets.QMessageBox.critical') as mock_critical:
+            gui._training_finished(False, "Training failed!")
+            mock_critical.assert_called_once()
+        
+        # Verify UI state reset
+        assert not gui.is_training
+        assert gui.start_btn.isEnabled()
+        assert not gui.stop_btn.isEnabled()
+        assert "failed" in gui.status_label.text()
+
+
+def test_create_app():
+    """Test create_app function."""
+    app = create_app()
+    assert app is not None
+    assert isinstance(app, QApplication)

--- a/tests/test_train_yolo_gui.py
+++ b/tests/test_train_yolo_gui.py
@@ -69,7 +69,7 @@ class TestTrainYoloGUI:
         assert gui.data_dir == str(temp_data_dir)
         assert gui.data_dir_label.text() == str(temp_data_dir)
 
-    def test_validation_no_data_directory(self, gui, qtbot):
+    def test_validation_no_data_directory(self, gui):
         """Test validation when no data directory is selected."""
         with patch('PySide6.QtWidgets.QMessageBox.critical') as mock_critical:
             gui.start_training()
@@ -79,7 +79,7 @@ class TestTrainYoloGUI:
         assert gui.start_btn.isEnabled()
         assert not gui.stop_btn.isEnabled()
 
-    def test_validation_no_images(self, gui, qtbot):
+    def test_validation_no_images(self, gui):
         """Test validation when directory has no images."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Directory with no files
@@ -91,7 +91,7 @@ class TestTrainYoloGUI:
                 
             assert gui.start_btn.isEnabled()
 
-    def test_validation_no_labels(self, gui, qtbot):
+    def test_validation_no_labels(self, gui):
         """Test validation when directory has images but no labels."""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)


### PR DESCRIPTION
Implements a user-friendly GUI for YOLO model training that wraps the existing train_yolo.py functionality.

**Features:**
- PySide6-based GUI with directory selection for images and annotations
- All training parameters configurable through UI controls
- Real-time training output display and progress monitoring
- Input validation and error handling
- Follows established patterns from annotation GUI

**Files Added:**
- `pretraining/train_yolo_gui.py` - Main GUI application
- `tests/test_train_yolo_gui.py` - Comprehensive test suite
- `run_train_gui.py` - Launcher script
- Updated `CLAUDE.md` with usage documentation

Fixes #134

Generated with [Claude Code](https://claude.ai/code)