### PR TITLE
Add segment counter to annotation pipeline and GUI

### DIFF
--- a/pretraining/annotation/annotation_config.py
+++ b/pretraining/annotation/annotation_config.py
@@ -23,12 +23,15 @@ class PipelineStatus:
         Total number of frames in the video(s) being processed.
     processed_frame_count: int
         Count of frames that have passed quality checks and been processed.
+    segment_count: int
+        Number of rider segments/trajectories detected so far.
     """
 
     last_function: str = ""
     current_frame: int = 0
     total_frames: int = 0
     processed_frame_count: int = 0
+    segment_count: int = 0
 
 
 @dataclass

--- a/pretraining/annotation/annotation_gui_pyqt.py
+++ b/pretraining/annotation/annotation_gui_pyqt.py
@@ -136,6 +136,9 @@ class AnnotationGUI(QMainWindow):
         self.frame_progress_label = QLabel("Processed: 0/0 frames")
         left_layout.addWidget(self.frame_progress_label)
         
+        self.segment_counter_label = QLabel("Segments detected: 0")
+        left_layout.addWidget(self.segment_counter_label)
+        
         # Add left panel to splitter
         main_splitter.addWidget(left_panel)
         
@@ -381,6 +384,9 @@ class AnnotationGUI(QMainWindow):
             )
         else:
             self.frame_progress_label.setText("Processed: 0/0 frames")
+        
+        # Update segment counter
+        self.segment_counter_label.setText(f"Segments detected: {st.segment_count}")
 
 
 def create_app():

--- a/pretraining/annotation/annotation_pipeline.py
+++ b/pretraining/annotation/annotation_pipeline.py
@@ -731,6 +731,8 @@ def run(
                 current_segment_items = []
                 current_det_points = []
                 first_bbox_after_gap_video_frame_number = None
+                # Count the new segment that's about to start (including first segment and after gaps)
+                status.segment_count += 1
                 is_first_detection = False
             
             # Reset gap tracking and start/continue segment


### PR DESCRIPTION
Add segment counter to annotation pipeline and GUI

- Added segment_count field to PipelineStatus to track number of rider segments
- Updated annotation pipeline to increment segment counter when new segments start
- Modified GUI to display "Segments detected: X" label that updates in real-time
- Counter tracks both first detection and segments after gaps based on detection_gap_timeout_s

Fixes #140

🤖 Generated with [Claude Code](https://claude.ai/code)